### PR TITLE
Add a note about custom keybindings to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ OR
 2. CMD + Shift + P -> Format Selection
 ```
 
+### Custom keybindings
+
+If you don't like the defaults, you can rebind `editor.action.formatDocument` and `editor.action.formatSelection` in the keyboard shortcuts menu of vscode.
+
 ### Format On Save
 Respects `editor.formatOnSave` setting.
 


### PR DESCRIPTION
I was looking for a way to rebind `CMD + Shift + P` and it wasn't immediately obvious that I can rebind  `editor.action.formatDocument` and `editor.action.formatSelection`. So decided to add a little note to the readme 🤔 