### PR TITLE
Updated description of 'prettier.trailingComma'

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
             "all"
           ],
           "default": "none",
-          "description": "Controls the printing of trailing commas wherever possible"
+          "description": "Controls the printing of trailing commas wherever possible.\n Valid options:\n    'none' - No trailing commas\n    'es5' - Trailing commas where valid in ES5 (objects, arrays, etc)\n    'all' - Trailing commas wherever possible (function arguments)"
         },
         "prettier.bracketSpacing": {
           "type": "boolean",


### PR DESCRIPTION
## Problem:

While editing prettier settings in vscode settings page, the description of property 'prettier.trailingComma'  is lacking. 

The original description was not intuitive and lacked the list of available option. (this is somewhat mitigated by vscode intellisense)

## Resolution:

Updated the description to be same as in README