### PR TITLE
Use prettier@1.8.0 to remove *Enable settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+- Removed all `*Enable` settings, these are now inferred from Prettier itself. Use scoped `editor.formatOnSave` to disable formatting some languages. (See README)
+- Markdown support
+- Prettier 1.8
 
 ## [0.24.0]
 - new setting, ignorePath. Ignore files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
-- Removed all `*Enable` settings, these are now inferred from Prettier itself. Use scoped `editor.formatOnSave` to disable formatting some languages. (See README)
+- Removed all `*Enable` settings, these are now inferred from Prettier itself. Use scoped `editor.formatOnSave` to disable formatting some languages on save.
+(See README)
 - Markdown support
-- Prettier 1.8
+- Prettier 1.8.2
 
 ## [0.24.0]
 - new setting, ignorePath. Ignore files.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ or only at the beginning of lines that may introduce ASI failures (semi: false)
 #### prettier.useTabs (default: false)
 If true, indent lines with tabs
 
+#### prettier.proseWrap (default: true)
+(Markdown) wrap prose over multiple lines.
+
 ### VSCode specific settings
 
 #### prettier.eslintIntegration (default: false) - JavaScript and TypeScript only

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Advanced feature. Use this to opt in / out prettier on various language ids. Res
 Use parser `graphql` for given language ids.
 Use with care.
 
+#### prettier.markdownEnable (default: ["markdown"])
+Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
+Use parser `markdown` for given language ids.
+Use with care.
+
 #### prettier.ignorePath (default: .prettierignore)
 Supply the path to an ignore file such as `.gitignore` or `.prettierignore`.
 Files which match will not be formatted. Set to `null` to not read ignore files. Restart required.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ If you don't like the defaults, you can rebind `editor.action.formatDocument` an
 ### Format On Save
 Respects `editor.formatOnSave` setting.
 
+You can turn off format-on-save on a per-language basis by scoping the setting:
+
+```json
+// Set the default
+"editor.formatOnSave": false,
+// Enable per-language
+"[javascript]": {
+    "editor.formatOnSave": true
+}
+```
+
 ## Settings
 
 ### Prettier's Settings
@@ -83,36 +94,6 @@ Other settings will only be fallbacks in case they could not be inferred from ES
 #### prettier.stylelintIntegration (default: false) - CSS, SCSS and LESS only 
 Use *[prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint)* instead of *prettier*.
 Other settings will only be fallbacks in case they could not be inferred from stylelint rules.
-
-#### prettier.javascriptEnable (default: ["javascript", "javascriptreact"])
-Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
-Use parser `babylon` or `flow` depending on `prettier.parser` for given language ids.
-Use with care.
-
-#### prettier.typescriptEnable (default: ["typescript", "typescriptreact"])
-Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
-Use parser `typescript` for given language ids.
-Use with care.
-
-#### prettier.cssEnable (default: ["css", "less", "scss"])
-Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
-Use parser `postcss` for given language ids.
-Use with care.
-
-#### prettier.jsonEnable (default: ["json"])
-Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
-Use parser `json` for given language ids.
-Use with care.
-
-#### prettier.graphqlEnable (default: ["graphql"])
-Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
-Use parser `graphql` for given language ids.
-Use with care.
-
-#### prettier.markdownEnable (default: ["markdown"])
-Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
-Use parser `markdown` for given language ids.
-Use with care.
 
 #### prettier.ignorePath (default: .prettierignore)
 Supply the path to an ignore file such as `.gitignore` or `.prettierignore`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,6 @@
       "integrity": "sha512-KQHAZeVsk4UIT9XaR6cn4WpHZzimK6UBD1UomQKfQQFmTlUHaNBzeuov+TM4+kigLO0IJt4I5OOsshcCyA9gSA==",
       "dev": true
     },
-    "@types/semver": {
-      "version": "5.3.32",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.32.tgz",
-      "integrity": "sha512-MdbWERx4JWmN4zP+skJy9Kio+Cddvmyn1k8x0S8UAqDoMgOJeobQo7yhlE4BfiimonHirgixWfva/hKUlXBsrw==",
-      "dev": true
-    },
     "acorn": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
@@ -3357,9 +3351,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.3.tgz",
-      "integrity": "sha1-jml0clJzkUscR0OZWd09O6U2ZLY="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.0.tgz",
+      "integrity": "sha512-7AiY2Bton6L1gHeppN2znZ3PHk5bPu5bhPsMIfzC1m/KaBt/4loq6Yw4cfutluSbYhrcydjqj1YmRrr/j0zXmQ=="
     },
     "prettier-eslint": {
       "version": "8.2.0",
@@ -3372,7 +3366,7 @@
         "indent-string": "3.2.0",
         "lodash.merge": "4.6.0",
         "loglevel-colored-level-prefix": "1.0.0",
-        "prettier": "1.7.3",
+        "prettier": "1.8.0",
         "pretty-format": "20.0.3",
         "require-relative": "0.8.7",
         "typescript": "2.4.2",
@@ -3392,7 +3386,7 @@
         "import-local": "0.1.1",
         "meow": "3.7.0",
         "pify": "3.0.0",
-        "prettier": "1.7.3",
+        "prettier": "1.8.0",
         "resolve-from": "4.0.0",
         "stylelint": "8.2.0",
         "temp-write": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-vscode",
-  "displayName": "Prettier - JavaScript formatter",
+  "displayName": "Prettier - Code formatter",
   "description": "VS Code plugin for prettier/prettier",
   "version": "0.24.0",
   "publisher": "esbenp",
@@ -32,7 +32,7 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "Prettier - JavaScript formatter configuration",
+      "title": "Prettier - Code formatter configuration",
       "properties": {
         "prettier.eslintIntegration": {
           "type": "boolean",
@@ -103,128 +103,6 @@
           "type": "boolean",
           "default": false,
           "description": "Indent lines with tabs"
-        },
-        "prettier.javascriptEnable": {
-          "description": "Advanced feature. Enable and use 'prettier.parser' parser for those language ids. Restart required",
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "enum": [
-                  "javascript",
-                  "javascriptreact"
-                ]
-              }
-            ]
-          },
-          "default": [
-            "javascript",
-            "javascriptreact"
-          ]
-        },
-        "prettier.typescriptEnable": {
-          "description": "Advanced feature. Enable and use typescript parser for those language ids. Restart required",
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "enum": [
-                  "typescript",
-                  "typescriptreact"
-                ]
-              }
-            ]
-          },
-          "default": [
-            "typescript",
-            "typescriptreact"
-          ]
-        },
-        "prettier.cssEnable": {
-          "description": "Advanced feature. Enable and use postcss parser for those language ids. Restart required",
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "enum": [
-                  "css",
-                  "less",
-                  "scss"
-                ]
-              }
-            ]
-          },
-          "default": [
-            "css",
-            "less",
-            "scss"
-          ]
-        },
-        "prettier.jsonEnable": {
-          "description": "Advanced feature. Enable and use json parser for those language ids. Restart required",
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "enum": [
-                  "json"
-                ]
-              }
-            ]
-          },
-          "default": [
-            "json"
-          ]
-        },
-        "prettier.graphqlEnable": {
-          "description": "Advanced feature. Enable and use graphql parser for those language ids. Restart required",
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "enum": [
-                  "graphql"
-                ]
-              }
-            ]
-          },
-          "default": [
-            "graphql"
-          ]
-        },
-        "prettier.markdownEnable": {
-          "description": "Advanced feature. Enable and use markdown parser for those language ids. Restart required",
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "enum": [
-                  "markdown"
-                ]
-              }
-            ]
-          },
-          "default": [
-            "markdown"
-          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,15 @@
       "type": "object",
       "title": "Prettier - Code formatter configuration",
       "properties": {
+        "prettier.disableLanguages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "A list of languages IDs to disable this extension on",
+          "scope": "resource"
+        },
         "prettier.eslintIntegration": {
           "type": "boolean",
           "default": false,
@@ -103,6 +112,11 @@
           "type": "boolean",
           "default": false,
           "description": "Indent lines with tabs"
+        },
+        "prettier.proseWrap": {
+          "type": "boolean",
+          "default": true,
+          "description": "(Markdown) wrap prose over multiple lines"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
   "dependencies": {
     "prettier-stylelint": "^0.4.1",
     "ignore": "^3.3.5",
-    "prettier": "1.8.0",
+    "prettier": "1.8.2",
     "prettier-eslint": "^8.2.0",
     "read-pkg-up": "2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -206,6 +206,25 @@
           "default": [
             "graphql"
           ]
+        },
+        "prettier.markdownEnable": {
+          "description": "Advanced feature. Enable and use markdown parser for those language ids. Restart required",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "markdown"
+                ]
+              }
+            ]
+          },
+          "default": [
+            "markdown"
+          ]
         }
       }
     },
@@ -234,7 +253,6 @@
   "devDependencies": {
     "@types/mocha": "^2.2.43",
     "@types/node": "^7.0.39",
-    "@types/semver": "^5.3.31",
     "cross-env": "^5.0.5",
     "mocha": "^3.5.3",
     "typescript": "^2.4.2",
@@ -243,9 +261,8 @@
   "dependencies": {
     "prettier-stylelint": "^0.4.1",
     "ignore": "^3.3.5",
-    "prettier": "1.7.3",
+    "prettier": "1.8.0",
     "prettier-eslint": "^8.2.0",
-    "read-pkg-up": "2.0.0",
-    "semver": "^5.4.1"
+    "read-pkg-up": "2.0.0"
   }
 }

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -20,6 +20,7 @@ import {
     PrettierEslintFormat,
     ParserOption,
     PrettierStylelint,
+    PrettierConfig,
 } from './types.d';
 
 const bundledPrettier = require('prettier') as Prettier;
@@ -47,6 +48,10 @@ async function format(
         'prettier'
     ) as any;
     const localPrettier = requireLocalPkg(fileName, 'prettier') as Prettier;
+
+    if (vscodeConfig.disableLanguages.includes(languageId)) {
+        return text;
+    }
 
     /*
     handle trailingComma changes boolean -> string
@@ -92,7 +97,8 @@ async function format(
             parser: parser,
             semi: vscodeConfig.semi,
             useTabs: vscodeConfig.useTabs,
-        },
+            proseWrap: vscodeConfig.proseWrap,
+        } as PrettierConfig,
         customOptions,
         fileOptions
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,21 +1,17 @@
-import { languages, ExtensionContext, DocumentSelector } from 'vscode';
+import { languages, ExtensionContext } from 'vscode';
 import EditProvider from './PrettierEditProvider';
 import { setupErrorHandler, registerDisposables } from './errorHandler';
-import { getConfig, allEnabledLanguages } from './utils';
+import { allEnabledLanguages, allJSLanguages } from './utils';
 import configFileListener from './configCacheHandler';
 import ignoreFileHandler from './ignoreFileHandler';
 
 export function activate(context: ExtensionContext) {
-    const config = getConfig();
     const { fileIsIgnored } = ignoreFileHandler(context.subscriptions);
     const editProvider = new EditProvider(fileIsIgnored);
     const languageSelector = allEnabledLanguages();
 
-    // CSS/json/graphql doesn't work with range yet.
-    const rangeLanguageSelector: DocumentSelector = [
-        ...config.javascriptEnable,
-        ...config.typescriptEnable,
-    ];
+    // Range selection is only supported for JS/TS
+    const rangeLanguageSelector = allJSLanguages();
 
     context.subscriptions.push(
         languages.registerDocumentRangeFormattingEditProvider(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,10 @@
 export type ParserOption =
     | 'babylon'
     | 'flow'
-    | 'postcss'
+    | 'postcss' // deprecated
+    | 'css'
+    | 'less'
+    | 'scss'
     | 'typescript'
     | 'json'
     | 'graphql'
@@ -17,7 +20,7 @@ interface PrettierSupportInfo {
     languages: {
         name: string,
         since: string,
-        parsers: string[],
+        parsers: ParserOption[],
         group?: string,
         tmScope: string,
         aceMode: string,
@@ -63,30 +66,6 @@ interface ExtensionConfig {
      * Path to '.prettierignore' or similar.
      */
     ignorePath: string;
-    /**
-     * Language ids to run javascript prettier on.
-     */
-    javascriptEnable: ('javascript' | 'javascriptreact' | string)[];
-    /**
-     * Language ids to run typescript prettier on.
-     */
-    typescriptEnable: ('typescript' | 'typescriptreact' | string)[];
-    /**
-     * Language ids to run postcss prettier on.
-     */
-    cssEnable: ('css' | 'less' | 'scss' | string)[];
-    /**
-     * Language ids to run json prettier on
-     */
-    jsonEnable: ('json' | string)[];
-    /**
-     * Language ids to run graphql prettier on
-     */
-    graphqlEnable: ('graphql' | string)[];
-    /**
-     * Language ids to run markdown prettier on
-     */
-    markdownEnable: ('markdown' | string)[];
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,12 +4,32 @@ export type ParserOption =
     | 'postcss'
     | 'typescript'
     | 'json'
-    | 'graphql';
+    | 'graphql'
+    | 'markdown';
+
 type TrailingCommaOption =
     | 'none'
     | 'es5'
     | 'all'
     | boolean; /* deprecated boolean*/
+
+interface PrettierSupportInfo {
+    languages: {
+        name: string,
+        since: string,
+        parsers: string[],
+        group?: string,
+        tmScope: string,
+        aceMode: string,
+        codemirrorMode: string,
+        codemirrorMimeType: string,
+        aliases?: string[],
+        extensions: string[],
+        filenames?: string[],
+        linguistLanguageId: number,
+        vscodeLanguageIds: string[],
+    }[];
+}
 
 /**
  * Prettier configuration
@@ -63,6 +83,10 @@ interface ExtensionConfig {
      * Language ids to run graphql prettier on
      */
     graphqlEnable: ('graphql' | string)[];
+    /**
+     * Language ids to run markdown prettier on
+     */
+    markdownEnable: ('markdown' | string)[];
 }
 
 /**
@@ -81,6 +105,7 @@ export interface Prettier {
         }
     ) => Promise<PrettierConfig>;
     clearConfigCache: () => void;
+    getSupportInfo(version?: string): PrettierSupportInfo;
     readonly version: string;
 }
 type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -47,6 +47,7 @@ export interface PrettierConfig {
     parser: ParserOption;
     semi: boolean;
     useTabs: boolean;
+    proseWrap: boolean;
 }
 /**
  * prettier-vscode specific configuration
@@ -66,6 +67,10 @@ interface ExtensionConfig {
      * Path to '.prettierignore' or similar.
      */
     ignorePath: string;
+    /**
+     * Array of language IDs to ignore
+     */
+    disableLanguages: string[];
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,10 @@
 import { workspace, Disposable, DocumentSelector, Uri } from 'vscode';
-import { PrettierVSCodeConfig, Prettier, PrettierSupportInfo } from './types.d';
+import {
+    PrettierVSCodeConfig,
+    Prettier,
+    PrettierSupportInfo,
+    ParserOption,
+} from './types.d';
 
 let currentRootPath: string = workspace.rootPath!;
 
@@ -20,23 +25,39 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
     return workspace.getConfiguration('prettier', uri) as any;
 }
 
+export function getParsersFromLanguageId(
+    languageId: string,
+    version: string
+): ParserOption[] {
+    const language = getSupportLanguages().find(lang =>
+        lang.vscodeLanguageIds.includes(languageId)
+    );
+    if (!language) {
+        return [];
+    }
+    return language.parsers;
+}
+
 export function allEnabledLanguages(): DocumentSelector {
-    return (require('prettier') as Prettier)
-        .getSupportInfo()
-        .languages.reduce(
-            (ids, language) => [...ids, ...language.vscodeLanguageIds],
-            []
-        );
+    return getSupportLanguages().reduce(
+        (ids, language) => [...ids, ...language.vscodeLanguageIds],
+        [] as string[]
+    );
 }
 
 export function allJSLanguages(): DocumentSelector {
     return getGroup('JavaScript')
         .filter(language => language.group === 'JavaScript')
-        .reduce((ids, language) => [...ids, ...language.vscodeLanguageIds], []);
+        .reduce(
+            (ids, language) => [...ids, ...language.vscodeLanguageIds],
+            [] as string[]
+        );
 }
 
 export function getGroup(group: string): PrettierSupportInfo['languages'] {
-    return (require('prettier') as Prettier)
-        .getSupportInfo()
-        .languages.filter(language => language.group === group);
+    return getSupportLanguages().filter(language => language.group === group);
+}
+
+function getSupportLanguages() {
+    return (require('prettier') as Prettier).getSupportInfo().languages;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,5 +29,6 @@ export function allEnabledLanguages(): DocumentSelector {
         ...config.cssEnable,
         ...config.jsonEnable,
         ...config.graphqlEnable,
+        ...config.markdownEnable,
     ];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { workspace, Disposable, DocumentSelector, Uri } from 'vscode';
-import { PrettierVSCodeConfig } from './types.d';
+import { PrettierVSCodeConfig, Prettier, PrettierSupportInfo } from './types.d';
 
 let currentRootPath: string = workspace.rootPath!;
 
@@ -21,14 +21,22 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
 }
 
 export function allEnabledLanguages(): DocumentSelector {
-    const config = getConfig();
+    return (require('prettier') as Prettier)
+        .getSupportInfo()
+        .languages.reduce(
+            (ids, language) => [...ids, ...language.vscodeLanguageIds],
+            []
+        );
+}
 
-    return [
-        ...config.javascriptEnable,
-        ...config.typescriptEnable,
-        ...config.cssEnable,
-        ...config.jsonEnable,
-        ...config.graphqlEnable,
-        ...config.markdownEnable,
-    ];
+export function allJSLanguages(): DocumentSelector {
+    return getGroup('JavaScript')
+        .filter(language => language.group === 'JavaScript')
+        .reduce((ids, language) => [...ids, ...language.vscodeLanguageIds], []);
+}
+
+export function getGroup(group: string): PrettierSupportInfo['languages'] {
+    return (require('prettier') as Prettier)
+        .getSupportInfo()
+        .languages.filter(language => language.group === group);
 }


### PR DESCRIPTION
This is obviously a breaking change but it greatly simplifies the process of supporting new languages (only bumping bundled prettier is required now).

Can't really see a reason to keep the `*Enable` settings any more...

We could do a 1.0.0 release with this and #252.

Fixes #237