### PR TITLE
Fix settings file typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Settings will be read from:
 1. File system, first matching file in
     1. `package.json` - `prettier` key
     1. `.prettierrc`
-    1. `.prettier.config.js`
+    1. `prettier.config.js`
 1. VSCode prettier's settings, described below
 1. VSCode prettier's default settings
 


### PR DESCRIPTION
Looking at the [docs](https://prettier.io/docs/en/configuration.html), it shouldn't have that dot

https://github.com/prettier/prettier-vscode/blob/221e65c8e245aaea02dc4deb2a566680c3f73caa/src/configCacheHandler.ts#L11