### PR TITLE
remove osx from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
  - "8"
 os:
-  - osx
   - linux
 addons:
   apt:


### PR DESCRIPTION
I'd like to remove OSX tests from running on travis.

They are slow!
And I don't think they bring a lot to the table. We make no system call...