### PR TITLE
prettier 1.9 and config handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+- Prettier 1.9
+- New option: requireConfig (boolean) Format only files which have a prettier config (.prettierrc, ...)
+- Don't merge editor's options into prettier config
 
 ## [0.25.0]
 - Multi-root support.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ or only at the beginning of lines that may introduce ASI failures (semi: false)
 #### prettier.useTabs (default: false)
 If true, indent lines with tabs
 
-#### prettier.proseWrap (default: true)
+#### prettier.proseWrap (default: 'preserve')
 (Markdown) wrap prose over multiple lines.
+
+#### prettier.arrowParens (default: 'avoid')
+Include parentheses around a sole arrow function parameter
 
 ### VSCode specific settings
 
@@ -97,6 +100,9 @@ Other settings will only be fallbacks in case they could not be inferred from ES
 #### prettier.stylelintIntegration (default: false) - CSS, SCSS and LESS only 
 Use *[prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint)* instead of *prettier*.
 Other settings will only be fallbacks in case they could not be inferred from stylelint rules.
+
+#### prettier.requireConfig (default: false)
+Require a 'prettierconfig' to format
 
 #### prettier.ignorePath (default: .prettierignore)
 Supply the path to an ignore file such as `.gitignore` or `.prettierignore`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,21 @@
   "requires": true,
   "dependencies": {
     "@types/mocha": {
-      "version": "2.2.43",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
-      "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
+      "version": "2.2.44",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
+      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.39.tgz",
-      "integrity": "sha512-KQHAZeVsk4UIT9XaR6cn4WpHZzimK6UBD1UomQKfQQFmTlUHaNBzeuov+TM4+kigLO0IJt4I5OOsshcCyA9gSA==",
+      "version": "7.0.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.48.tgz",
+      "integrity": "sha512-LLlXafM3BD52MH056tHxTXO8JFCnpJJQkdzIU3+m8ew+CXJY/5zIXgDNb4TK/QFvlI8QexLS5tL+sE0Qhegr1w==",
       "dev": true
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -59,9 +59,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -172,23 +172,139 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
     },
-    "babel-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
       }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -381,6 +497,11 @@
         "supports-color": "2.0.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
     "circular-json": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
@@ -400,14 +521,14 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
       "dev": true
     },
     "clone-buffer": {
@@ -484,11 +605,11 @@
       }
     },
     "common-tags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
-      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.5.1.tgz",
+      "integrity": "sha512-NrUYGY5TApAk9KB+IZXkR3GR4tA3g26HDsoiGt4kCMHZ727gOGkC+UNfq0Z22jE15bLkc/6RV5Jw1RBW6Usg6A==",
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "concat-map": {
@@ -520,15 +641,14 @@
       }
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -565,9 +685,9 @@
       }
     },
     "cross-env": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.0.5.tgz",
-      "integrity": "sha1-Q4PTZNlmCHPdGFs5ivO/717//vM=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.1.tgz",
+      "integrity": "sha512-Wtvr+z0Z06KO1JxjfRRsPC+df7biIOiuV4iZ73cThjFGkH+ULBZq1MkBdywEcJC4cTDbO6c8IjgRjfswx3YTBA==",
       "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
@@ -692,6 +812,14 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
@@ -704,12 +832,11 @@
       "integrity": "sha1-/uGnxD9jvnXz9nnoUmLaXxAnZKc="
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dot-prop": {
@@ -816,32 +943,32 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
-      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.12.1.tgz",
+      "integrity": "sha512-28hOYej+NZ/R5H1yMvyKa1+bPlu+fnsIAQffK6hxXgvmXnImos2bA5XfCn5dYv2k2mrKj+/U/Z4L5ICWxC7TQw==",
       "requires": {
-        "ajv": "5.2.2",
-        "babel-code-frame": "6.22.0",
-        "chalk": "2.1.0",
+        "ajv": "5.5.1",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
-        "doctrine": "2.0.0",
+        "debug": "3.1.0",
+        "doctrine": "2.0.2",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
+        "globals": "11.0.1",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.3",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -849,7 +976,7 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
@@ -860,14 +987,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-regex": {
@@ -884,14 +1011,27 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.0.1.tgz",
+          "integrity": "sha1-Eqh7sBDlFUOWrMU14eQ/x1Ow5eg="
         },
         "has-flag": {
           "version": "2.0.0",
@@ -907,9 +1047,9 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -926,11 +1066,11 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1035,13 +1175,13 @@
       }
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
-        "iconv-lite": "0.4.18",
-        "jschardet": "1.5.1",
-        "tmp": "0.0.31"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -1083,8 +1223,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1470,7 +1609,7 @@
       "requires": {
         "gulp-util": "3.0.8",
         "multimatch": "2.1.0",
-        "streamfilter": "1.0.5"
+        "streamfilter": "1.0.6"
       }
     },
     "gulp-gunzip": {
@@ -1594,7 +1733,7 @@
           "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
             "cloneable-readable": "1.0.0",
@@ -1611,7 +1750,7 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
         "strip-bom": "2.0.0",
         "through2": "2.0.3",
@@ -1633,7 +1772,7 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -1716,8 +1855,8 @@
         "through2": "2.0.3",
         "vinyl": "2.1.0",
         "vinyl-fs": "2.4.4",
-        "yauzl": "2.9.0",
-        "yazl": "2.4.2"
+        "yauzl": "2.9.1",
+        "yazl": "2.4.3"
       },
       "dependencies": {
         "clone": {
@@ -1836,6 +1975,15 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -1858,14 +2006,14 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -1916,15 +2064,15 @@
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
     "inquirer": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
-      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "2.0.0",
-        "chalk": "2.1.0",
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
-        "external-editor": "2.0.4",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -1950,24 +2098,19 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "rx-lite": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -1978,13 +2121,21 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
             "has-flag": "2.0.0"
           }
         }
+      }
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
       }
     },
     "is": {
@@ -2240,10 +2391,10 @@
       "dev": true,
       "optional": true
     },
-    "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2264,6 +2415,11 @@
         "jsonify": "0.0.0"
       }
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2275,6 +2431,11 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2575,9 +2736,9 @@
       }
     },
     "loglevel": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
-      "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz",
+      "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ="
     },
     "loglevel-colored-level-prefix": {
       "version": "1.0.0",
@@ -2585,7 +2746,15 @@
       "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
       "requires": {
         "chalk": "1.1.3",
-        "loglevel": "1.4.1"
+        "loglevel": "1.6.0"
+      }
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -2997,6 +3166,11 @@
         "readable-stream": "2.3.3"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3147,9 +3321,9 @@
       }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
     "postcss": {
       "version": "6.0.13",
@@ -3329,26 +3503,27 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.0.tgz",
+      "integrity": "sha512-NMIs+QW5ACV7qZxAAz6Y1cBlaq9D24O0yKI357QL19ZkzDkGq/e0uIeZDdm8WZpyIgiY5a6IFY2YFhdZgCSJdw=="
     },
     "prettier-eslint": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.2.0.tgz",
-      "integrity": "sha512-OSx/0ULxWuIjeMO6KJoMVIDc7/Kj9a0wxUDzaGJTNiZXlNRq2bCl5jya8p42OQCVJzp1HnnQyGrWb+6/5+jbJQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.2.4.tgz",
+      "integrity": "sha512-jJx8gSRZe5WJ0lnPNfckFtcke/hi//WNnOgLxo5F3k0p5VUeLAmrlLAc0D8qWQNHyqWjb8wlVvsdptkWwg6gqw==",
       "requires": {
-        "common-tags": "1.4.0",
+        "babel-core": "6.26.0",
+        "common-tags": "1.5.1",
         "dlv": "1.1.0",
-        "eslint": "4.6.1",
+        "eslint": "4.12.1",
         "indent-string": "3.2.0",
         "lodash.merge": "4.6.0",
         "loglevel-colored-level-prefix": "1.0.0",
-        "prettier": "1.8.2",
-        "pretty-format": "20.0.3",
+        "prettier": "1.9.0",
+        "pretty-format": "21.2.1",
         "require-relative": "0.8.7",
-        "typescript": "2.4.2",
-        "typescript-eslint-parser": "7.0.0"
+        "typescript": "2.6.2",
+        "typescript-eslint-parser": "8.0.1"
       }
     },
     "prettier-stylelint": {
@@ -3360,11 +3535,11 @@
         "debug": "3.1.0",
         "get-stdin": "5.0.1",
         "globby": "6.1.0",
-        "ignore": "3.3.5",
+        "ignore": "3.3.7",
         "import-local": "0.1.1",
         "meow": "3.7.0",
         "pify": "3.0.0",
-        "prettier": "1.8.2",
+        "prettier": "1.9.0",
         "resolve-from": "4.0.0",
         "stylelint": "8.2.0",
         "temp-write": "3.3.0",
@@ -3412,23 +3587,33 @@
       }
     },
     "pretty-format": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
-      "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "requires": {
-        "ansi-regex": "2.1.1",
-        "ansi-styles": "3.1.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
             "color-convert": "1.9.0"
           }
         }
       }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -3580,9 +3765,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
     },
     "regex-cache": {
       "version": "0.4.3",
@@ -3670,9 +3855,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
           "dev": true,
           "requires": {
             "co": "4.6.0",
@@ -3745,7 +3930,7 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.3.0",
+            "ajv": "5.5.1",
             "har-schema": "2.0.0"
           }
         },
@@ -3875,16 +4060,16 @@
       }
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "3.1.2"
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -3923,6 +4108,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -3943,20 +4133,11 @@
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
-      "dev": true,
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "source-map": "0.5.6"
       }
     },
     "sparkles": {
@@ -4048,9 +4229,9 @@
       "dev": true
     },
     "streamfilter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
-      "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.6.tgz",
+      "integrity": "sha512-JM3zxd/lvOuo+EZJlZNYdQucfybA+Jr6jRtZwWlMAq1dAV0LIjZrqSNBBK62qCtflJ8rL/+cAnxy69CPhkTJNA==",
       "dev": true,
       "requires": {
         "readable-stream": "2.3.3"
@@ -4180,7 +4361,7 @@
         "globby": "6.1.0",
         "globjoin": "0.1.4",
         "html-tags": "2.0.0",
-        "ignore": "3.3.5",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "known-css-properties": "0.4.1",
         "lodash": "4.17.4",
@@ -4397,9 +4578,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -4412,6 +4593,11 @@
       "requires": {
         "extend-shallow": "2.0.1"
       }
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -4426,6 +4612,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tryit": {
       "version": "1.0.3",
@@ -4459,24 +4650,17 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "typescript-eslint-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-7.0.0.tgz",
-      "integrity": "sha1-vlfYdo43cHr4JeM56irxjXOTyrs=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-8.0.1.tgz",
+      "integrity": "sha1-6MrFN9mW4Ww9uw18TVCXmeZ6/gw=",
       "requires": {
         "lodash.unescape": "4.0.1",
-        "semver": "5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-        }
+        "semver": "5.4.1"
       }
     },
     "uniq": {
@@ -4523,9 +4707,9 @@
       }
     },
     "url-parse": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
-      "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
       "dev": true,
       "requires": {
         "querystringify": "1.0.0",
@@ -4590,7 +4774,7 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
+        "clone": "1.0.3",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
@@ -4635,7 +4819,7 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -4705,9 +4889,9 @@
       }
     },
     "vscode": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.6.tgz",
-      "integrity": "sha1-Ru0a+iwbnWifY5TI8WvR1xkPdfs=",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.10.tgz",
+      "integrity": "sha512-MvFXXSGuhw0Q6GC6dQrnRc0ES+63wpttGIoYGBMQnoS9JFCCNC/rWfX0lBCHJyuKL2Q8CYg0ROsMEHbHVwEtVw==",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
@@ -4722,7 +4906,7 @@
         "request": "2.83.0",
         "semver": "5.4.1",
         "source-map-support": "0.5.0",
-        "url-parse": "1.1.9",
+        "url-parse": "1.2.0",
         "vinyl-source-stream": "1.1.0"
       },
       "dependencies": {
@@ -4775,6 +4959,21 @@
             "he": "1.1.1",
             "mkdirp": "0.5.1",
             "supports-color": "4.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
           }
         },
         "supports-color": {
@@ -4869,9 +5068,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yauzl": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.0.tgz",
-      "integrity": "sha1-knqoQ5Lu0FMSRJa26o/B9S2uW1I=",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
@@ -4879,9 +5078,9 @@
       }
     },
     "yazl": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
-      "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+      "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3503,14 +3503,14 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.0.tgz",
-      "integrity": "sha512-NMIs+QW5ACV7qZxAAz6Y1cBlaq9D24O0yKI357QL19ZkzDkGq/e0uIeZDdm8WZpyIgiY5a6IFY2YFhdZgCSJdw=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.1.tgz",
+      "integrity": "sha512-oYpQsZk7/0o8+YJUB0LfjkTYQa79gUIF2ESeqvG23IzcgqqvmeOE4+lMG7E/UKX3q3RIj8JHSfhrXWhon1L+zA=="
     },
     "prettier-eslint": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.2.4.tgz",
-      "integrity": "sha512-jJx8gSRZe5WJ0lnPNfckFtcke/hi//WNnOgLxo5F3k0p5VUeLAmrlLAc0D8qWQNHyqWjb8wlVvsdptkWwg6gqw==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.2.5.tgz",
+      "integrity": "sha512-m2h8XUq4lmDHYVohqV8AbnUfUl7Dqn6dQSODPATTkIo+vInE9JXsBRQ4Jb3HxoHB0W3sGgqxCFhLI+ixtCOyWg==",
       "requires": {
         "babel-core": "6.26.0",
         "common-tags": "1.5.1",
@@ -3519,7 +3519,7 @@
         "indent-string": "3.2.0",
         "lodash.merge": "4.6.0",
         "loglevel-colored-level-prefix": "1.0.0",
-        "prettier": "1.9.0",
+        "prettier": "1.9.1",
         "pretty-format": "21.2.1",
         "require-relative": "0.8.7",
         "typescript": "2.6.2",
@@ -3539,7 +3539,7 @@
         "import-local": "0.1.1",
         "meow": "3.7.0",
         "pify": "3.0.0",
-        "prettier": "1.9.0",
+        "prettier": "1.9.1",
         "resolve-from": "4.0.0",
         "stylelint": "8.2.0",
         "temp-write": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,12 @@
           "description": "Use 'prettier-stylelint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from stylelint rules.",
           "scope": "resource"
         },
+        "prettier.requireConfig":{
+          "type": "boolean",
+          "default": false,
+          "description": "Require a 'prettierconfig' to format",
+          "scope": "resource"
+        },
         "prettier.ignorePath": {
           "type": "string",
           "default": ".prettierignore",
@@ -128,9 +134,20 @@
           "scope": "resource"
         },
         "prettier.proseWrap": {
-          "type": "boolean",
-          "default": true,
+          "type": "string",
+          "enum": ["preserve", "always", "never"],
+          "default": "preserve",
           "description": "(Markdown) wrap prose over multiple lines"
+        },
+        "prettier.arrowParens": {
+          "type": "string",
+          "enum": [
+            "avoid",
+            "always"
+          ],
+          "default": "avoid",
+          "description": "Include parentheses around a sole arrow function parameter",
+          "scope": "resource"
         }
       }
     },
@@ -157,18 +174,18 @@
     "version": "node ./scripts/version.js && git add CHANGELOG.md"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.43",
-    "@types/node": "^7.0.39",
-    "cross-env": "^5.0.5",
+    "@types/mocha": "^2.2.44",
+    "@types/node": "^7.0.48",
+    "cross-env": "^5.1.1",
     "mocha": "^3.5.3",
-    "typescript": "^2.4.2",
-    "vscode": "^1.1.6"
+    "typescript": "^2.6.2",
+    "vscode": "^1.1.10"
   },
   "dependencies": {
+    "ignore": "^3.3.7",
+    "prettier": "1.9.0",
+    "prettier-eslint": "^8.2.4",
     "prettier-stylelint": "^0.4.1",
-    "ignore": "^3.3.5",
-    "prettier": "1.8.2",
-    "prettier-eslint": "^8.2.0",
     "read-pkg-up": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
           "description": "Use 'prettier-stylelint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from stylelint rules.",
           "scope": "resource"
         },
-        "prettier.requireConfig":{
+        "prettier.requireConfig": {
           "type": "boolean",
           "default": false,
           "description": "Require a 'prettierconfig' to format",
@@ -135,7 +135,11 @@
         },
         "prettier.proseWrap": {
           "type": "string",
-          "enum": ["preserve", "always", "never"],
+          "enum": [
+            "preserve",
+            "always",
+            "never"
+          ],
           "default": "preserve",
           "description": "(Markdown) wrap prose over multiple lines"
         },
@@ -183,8 +187,8 @@
   },
   "dependencies": {
     "ignore": "^3.3.7",
-    "prettier": "1.9.0",
-    "prettier-eslint": "^8.2.4",
+    "prettier": "1.9.1",
+    "prettier-eslint": "^8.2.5",
     "prettier-stylelint": "^0.4.1",
     "read-pkg-up": "2.0.0"
   }

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -23,6 +23,10 @@ import {
 
 const bundledPrettier = require('prettier') as Prettier;
 /**
+ * HOLD style parsers (for stylelint integration)
+ */
+const STYLE_PARSERS: ParserOption[] = ['css', 'less', 'scss'];
+/**
  * Check if a given file has an associated prettierconfig.
  * @param filePath file's path
  */
@@ -139,7 +143,7 @@ async function format(
         );
     }
 
-    if (vscodeConfig.stylelintIntegration && parser === 'postcss') {
+    if (vscodeConfig.stylelintIntegration && STYLE_PARSERS.includes(parser)) {
         const prettierStylelint = require('prettier-stylelint') as PrettierStylelint;
         return safeExecution(
             prettierStylelint.format({

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -25,7 +25,7 @@ const bundledPrettier = require('prettier') as Prettier;
 /**
  * HOLD style parsers (for stylelint integration)
  */
-const STYLE_PARSERS: ParserOption[] = ['css', 'less', 'scss'];
+const STYLE_PARSERS: ParserOption[] = ['postcss', 'css', 'less', 'scss'];
 /**
  * Check if a given file has an associated prettierconfig.
  * @param filePath file's path

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -105,7 +105,7 @@ async function format(
 
     const hasConfig = await hasPrettierConfig(fileName);
 
-    if (hasConfig === null && vscodeConfig.requireConfig) {
+    if (!hasConfig && vscodeConfig.requireConfig) {
         return text;
     }
     const fileOptions = await bundledPrettier.resolveConfig(fileName, {

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -22,7 +22,41 @@ import {
 } from './types.d';
 
 const bundledPrettier = require('prettier') as Prettier;
+/**
+ * Check if a given file has an associated prettierconfig.
+ * @param filePath file's path
+ */
+async function hasPrettierConfig(filePath: string) {
+    return (await bundledPrettier.resolveConfig(filePath)) !== null;
+}
 
+/**
+ * Define which config should be used.
+ * If a prettierconfig exists, it returns itself.
+ * It merges prettierconfig into vscode's config (editorconfig).
+ * Priority:
+ * - additionalConfig
+ * - prettierConfig
+ * - vscodeConfig
+ * @param hasPrettierConfig a prettierconfig exists
+ * @param additionalConfig config we really want to see in. (range)
+ * @param prettierConfig prettier's file config
+ * @param vscodeConfig our config
+ */
+function mergeConfig(
+    hasPrettierConfig: boolean,
+    additionalConfig: Partial<PrettierConfig>,
+    prettierConfig: Partial<PrettierConfig>,
+    vscodeConfig: Partial<PrettierConfig>
+) {
+    return hasPrettierConfig
+        ? Object.assign(
+              { parser: vscodeConfig.parser }, // always merge our inferred parser in
+              prettierConfig,
+              additionalConfig
+          )
+        : Object.assign(vscodeConfig, prettierConfig, additionalConfig);
+}
 /**
  * Format the given text with user's configuration.
  * @param text Text to format
@@ -32,7 +66,7 @@ const bundledPrettier = require('prettier') as Prettier;
 async function format(
     text: string,
     { fileName, languageId, uri }: TextDocument,
-    customOptions: object
+    customOptions: Partial<PrettierConfig>
 ): Promise<string> {
     const vscodeConfig: PrettierVSCodeConfig = getConfig(uri);
     const localPrettier = requireLocalPkg(fileName, 'prettier') as Prettier;
@@ -41,17 +75,10 @@ async function format(
         return text;
     }
 
-    /*
-    handle trailingComma changes boolean -> string
-    */
-    let trailingComma = vscodeConfig.trailingComma;
-    if (trailingComma === true) {
-        trailingComma = 'es5';
-    } else if (trailingComma === false) {
-        trailingComma = 'none';
-    }
-
-    const dynamicParsers = getParsersFromLanguageId(languageId, localPrettier.version);
+    const dynamicParsers = getParsersFromLanguageId(
+        languageId,
+        localPrettier.version
+    );
     let useBundled = false;
     let parser: ParserOption;
 
@@ -72,24 +99,28 @@ async function format(
         lang.parsers.includes(parser)
     );
 
-    const fileOptions = await bundledPrettier.resolveConfig(fileName);
+    const hasConfig = await hasPrettierConfig(fileName);
 
-    const prettierOptions = Object.assign(
-        {
-            printWidth: vscodeConfig.printWidth,
-            tabWidth: vscodeConfig.tabWidth,
-            singleQuote: vscodeConfig.singleQuote,
-            trailingComma,
-            bracketSpacing: vscodeConfig.bracketSpacing,
-            jsxBracketSameLine: vscodeConfig.jsxBracketSameLine,
-            parser: parser,
-            semi: vscodeConfig.semi,
-            useTabs: vscodeConfig.useTabs,
-            proseWrap: vscodeConfig.proseWrap,
-        } as PrettierConfig,
-        customOptions,
-        fileOptions
-    );
+    if (hasConfig === null && vscodeConfig.requireConfig) {
+        return text;
+    }
+    const fileOptions = await bundledPrettier.resolveConfig(fileName, {
+        editorconfig: true,
+    });
+
+    const prettierOptions = mergeConfig(hasConfig, customOptions, fileOptions, {
+        printWidth: vscodeConfig.printWidth,
+        tabWidth: vscodeConfig.tabWidth,
+        singleQuote: vscodeConfig.singleQuote,
+        trailingComma: vscodeConfig.trailingComma,
+        bracketSpacing: vscodeConfig.bracketSpacing,
+        jsxBracketSameLine: vscodeConfig.jsxBracketSameLine,
+        parser: parser,
+        semi: vscodeConfig.semi,
+        useTabs: vscodeConfig.useTabs,
+        proseWrap: vscodeConfig.proseWrap,
+        arrowParens: vscodeConfig.arrowParens,
+    });
 
     if (vscodeConfig.eslintIntegration && doesParserSupportEslint) {
         return safeExecution(
@@ -125,9 +156,9 @@ async function format(
         return safeExecution(
             () => {
                 const warningMessage =
-                    `prettier@${localPrettier.version} doesn't support ${
-                        languageId
-                    }. ` +
+                    `prettier@${
+                        localPrettier.version
+                    } doesn't support ${languageId}. ` +
                     `Falling back to bundled prettier@${
                         bundledPrettier.version
                     }.`;
@@ -182,7 +213,10 @@ class PrettierEditProvider
         return this._provideEdits(document, {});
     }
 
-    private _provideEdits(document: TextDocument, options: object) {
+    private _provideEdits(
+        document: TextDocument,
+        options: Partial<PrettierConfig>
+    ) {
         if (!document.isUntitled && this._fileIsIgnored(document.fileName)) {
             return Promise.resolve([]);
         }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,7 @@
 export type ParserOption =
     | 'babylon'
     | 'flow'
+    | 'postcss' // deprecated, but may be found in getSupportInfo
     | 'css'
     | 'less'
     | 'scss'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,19 +18,19 @@ type TrailingCommaOption =
 
 interface PrettierSupportInfo {
     languages: {
-        name: string,
-        since: string,
-        parsers: ParserOption[],
-        group?: string,
-        tmScope: string,
-        aceMode: string,
-        codemirrorMode: string,
-        codemirrorMimeType: string,
-        aliases?: string[],
-        extensions: string[],
-        filenames?: string[],
-        linguistLanguageId: number,
-        vscodeLanguageIds: string[],
+        name: string;
+        since: string;
+        parsers: ParserOption[];
+        group?: string;
+        tmScope: string;
+        aceMode: string;
+        codemirrorMode: string;
+        codemirrorMimeType: string;
+        aliases?: string[];
+        extensions: string[];
+        filenames?: string[];
+        linguistLanguageId: number;
+        vscodeLanguageIds: string[];
     }[];
 }
 
@@ -47,7 +47,10 @@ export interface PrettierConfig {
     parser: ParserOption;
     semi: boolean;
     useTabs: boolean;
-    proseWrap: boolean;
+    proseWrap: 'preserve' | 'always' | 'never';
+    arrowParens: 'avoid' | 'always';
+    rangeStart: number;
+    rangeEnd: number;
 }
 /**
  * prettier-vscode specific configuration
@@ -68,6 +71,10 @@ interface ExtensionConfig {
      */
     ignorePath: string;
     /**
+     * If true will skip formatting if a prettierconfig isn't found.
+     */
+    requireConfig: boolean;
+    /**
      * Array of language IDs to ignore
      */
     disableLanguages: string[];
@@ -85,7 +92,11 @@ export interface Prettier {
             /**
              * Use cache, defaults to true.
              */
-            useCache: boolean;
+            useCache?: boolean;
+            /**
+             * read editorconfig, defaults to false.
+             */
+            editorconfig?: boolean;
         }
     ) => Promise<PrettierConfig>;
     clearConfigCache: () => void;
@@ -120,13 +131,13 @@ interface PrettierEslintOptions {
      * formatting with `prettier`. If not provided, prettier-eslint will attempt
      * to create the options based on the eslintConfig
      */
-    prettierOptions?: PrettierConfig;
+    prettierOptions?: Partial<PrettierConfig>;
     /**
      * The options to pass for
      * formatting with `prettier` if the given option is not inferrable from the
      * eslintConfig.
      */
-    fallbackPrettierOptions?: PrettierConfig;
+    fallbackPrettierOptions?: Partial<PrettierConfig>;
     /**
      * The level for the logs
      */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,6 @@
 export type ParserOption =
     | 'babylon'
     | 'flow'
-    | 'postcss' // deprecated
     | 'css'
     | 'less'
     | 'scss'
@@ -10,11 +9,7 @@ export type ParserOption =
     | 'graphql'
     | 'markdown';
 
-type TrailingCommaOption =
-    | 'none'
-    | 'es5'
-    | 'all'
-    | boolean; /* deprecated boolean*/
+type TrailingCommaOption = 'none' | 'es5' | 'all';
 
 interface PrettierSupportInfo {
     languages: {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -6,7 +6,7 @@ const prettier = require('prettier') as Prettier;
 // import * as PrettierVSCode from '../src/extension';
 
 const EXT_PARSER: { [ext: string]: ParserOption } = {
-    css: 'postcss',
+    css: 'css',
     json: 'json',
     ts: 'typescript',
 };
@@ -24,9 +24,11 @@ function formatSameAsPrettier(file: string) {
         const text = doc.getText();
         return vscode.window.showTextDocument(doc).then(
             () => {
+                console.time(file);
                 return vscode.commands
                     .executeCommand('editor.action.formatDocument')
                     .then(() => {
+                        console.timeEnd(file);
                         const prettierFormatted = prettier.format(text, {
                             parser:
                                 EXT_PARSER[path.extname(file).slice(1)] ||


### PR DESCRIPTION
* proseWrap config change
* Don't merge vscode's option in prettierConfig -- fix #248 
* dependencies bump
* Fix #273 add style parsers
+ arrowParens config
+ requireConfig config. Format only files with a prettierconfig -- fix #199
+ using resolveConfig + editorconfig -- fix #81 


- [x] Readme
- [x] Changelog
- [ ] ~~json validation for `prettierrc.json`~~ other PR

## Break

Don't handle deprecated options. Workaround: prettierconfig