### PR TITLE
Validate .prettierrc.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,10 @@
       {
         "fileMatch": ".prettierrc",
         "url": "http://json.schemastore.org/prettierrc"
+      },
+      {
+        "fileMatch": ".prettierrc.json",
+        "url": "http://json.schemastore.org/prettierrc"
       }
     ],
     "languages": [

--- a/src/configCacheHandler.ts
+++ b/src/configCacheHandler.ts
@@ -7,6 +7,10 @@ const prettier = require('prettier') as Prettier;
  */
 const PRETTIER_CONFIG_FILES = [
     '.prettierrc',
+    '.prettierrc.json',
+    '.prettierrc.yaml',
+    '.prettierrc.yml',
+    '.prettierrc.js',
     'package.json',
     'prettier.config.js',
 ];


### PR DESCRIPTION
with http://json.schemastore.org/prettierrc

Which seems a little outdated. :expressionless: 

Also added extensions to our config file watcher.