### PR TITLE
Disable formatter based on disableLanguages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 package.json
 package-lock.json
 testProject/
+testWorkspaceFolder/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "${workspaceRoot}/testProject",
+                "${workspaceRoot}/testWorkspace.code-workspace",
                 "--extensions-dir=${workspaceRoot}/.", // no other extension loaded
                 "--extensionDevelopmentPath=${workspaceRoot}",
                 "--extensionTestsPath=${workspaceRoot}/out/test"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,10 @@ out/test/**
 test/**
 src/**
 testProject/**
+testWorkspaceFolder/**
+testWorkspace.code-workspace
+.prettierignore
+.travis.yml
 scripts/**
 **/*.map
 .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+- Disabling a language `disableLanguages` now allows to use an other formatter. NOT when disabling in a sub workspace folder (noop)
 
 ## [1.0.0]
 - Prettier 1.9

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Files which match will not be formatted. Set to `null` to not read ignore files.
 
 #### prettier.disableLanguages (default: [])
 A list of languages IDs to disable this extension on. Restart required.
+*Note: Disabling a language enabled in a parent folder will prevent formatting instead of letting any other formatter to run*
 
 ## Prettier resolution
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Supply the path to an ignore file such as `.gitignore` or `.prettierignore`.
 Files which match will not be formatted. Set to `null` to not read ignore files. Restart required.
 
 #### prettier.disableLanguages (default: [])
-A list of languages IDs to disable this extension on.
+A list of languages IDs to disable this extension on. Restart required.
 
 ## Prettier resolution
 

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cross-env CODE_TESTS_WORKSPACE=testProject node ./node_modules/vscode/bin/test",
+    "test": "cross-env CODE_TESTS_WORKSPACE=testWorkspace.code-workspace node ./node_modules/vscode/bin/test",
     "version": "node ./scripts/version.js && git add CHANGELOG.md"
   },
   "devDependencies": {

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -75,6 +75,9 @@ async function format(
     const vscodeConfig: PrettierVSCodeConfig = getConfig(uri);
     const localPrettier = requireLocalPkg(fileName, 'prettier') as Prettier;
 
+    // This has to stay, as it allows to skip in sub workspaceFolders. Sadly noop.
+    // wf1  (with "lang") -> glob: "wf1/**"
+    // wf1/wf2  (without "lang") -> match "wf1/**"
     if (vscodeConfig.disableLanguages.includes(languageId)) {
         return text;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,9 @@ interface Selectors {
 
 let formatterHandler: undefined | Disposable;
 let rangeFormatterHandler: undefined | Disposable;
+/**
+ * Dispose formatters
+ */
 function disposeHandlers() {
     if (formatterHandler) {
         formatterHandler.dispose();
@@ -31,7 +34,10 @@ function disposeHandlers() {
     formatterHandler = undefined;
     rangeFormatterHandler = undefined;
 }
-
+/**
+ * Build formatter selectors for a given workspace folder
+ * @param wf workspace folder
+ */
 function selectorsCreator(wf: WorkspaceFolder) {
     const allLanguages = allEnabledLanguages();
     const allRangeLanguages = allJSLanguages();
@@ -52,7 +58,9 @@ function selectorsCreator(wf: WorkspaceFolder) {
 
     return { languageSelector, rangeLanguageSelector };
 }
-
+/**
+ * Build formatter selectors
+ */
 function selectors(): Selectors {
     const allLanguages = allEnabledLanguages();
     const allRangeLanguages = allJSLanguages();
@@ -79,10 +87,7 @@ function selectors(): Selectors {
         l => ({ language: l, scheme: 'untitled' })
     );
     return workspace.workspaceFolders.reduce(
-        (
-            previous,
-            workspaceFolder
-        ) => {
+        (previous, workspaceFolder) => {
             let { languageSelector, rangeLanguageSelector } = previous;
             const select = selectorsCreator(workspaceFolder);
             return {
@@ -107,11 +112,11 @@ export function activate(context: ExtensionContext) {
     function registerFormatter() {
         disposeHandlers();
         const { languageSelector, rangeLanguageSelector } = selectors();
-        formatterHandler = languages.registerDocumentRangeFormattingEditProvider(
+        rangeFormatterHandler = languages.registerDocumentRangeFormattingEditProvider(
             rangeLanguageSelector,
             editProvider
         );
-        rangeFormatterHandler = languages.registerDocumentFormattingEditProvider(
+        formatterHandler = languages.registerDocumentFormattingEditProvider(
             languageSelector,
             editProvider
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,18 +1,80 @@
-import { languages, ExtensionContext } from 'vscode';
+import {
+    languages,
+    ExtensionContext,
+    workspace,
+    DocumentFilter,
+    DocumentSelector,
+    RelativePattern,
+} from 'vscode';
 import EditProvider from './PrettierEditProvider';
 import { setupErrorHandler, registerDisposables } from './errorHandler';
-import { allEnabledLanguages, allJSLanguages } from './utils';
+import { allEnabledLanguages, allJSLanguages, getConfig } from './utils';
 import configFileListener from './configCacheHandler';
 import ignoreFileHandler from './ignoreFileHandler';
+interface Selector {
+    rangeLanguageSelector: DocumentSelector;
+    languageSelector: DocumentSelector;
+}
+function selectors(): Selector {
+    const allLanguages = allEnabledLanguages();
+    const allRangeLanguages = allJSLanguages();
+    if (workspace.workspaceFolders === undefined) {
+        // no workspace opened
+        const { disableLanguages } = getConfig();
+        const languageSelector = allLanguages.filter(
+            l => !disableLanguages.includes(l)
+        );
+        const rangeLanguageSelector = allRangeLanguages.filter(
+            l => !disableLanguages.includes(l)
+        );
+        return { languageSelector, rangeLanguageSelector };
+    }
+    // at least 1 workspace
+
+    // TODO: untitled files to concat.
+    return workspace.workspaceFolders.reduce(
+        (
+            ret: {
+                languageSelector: DocumentFilter[];
+                rangeLanguageSelector: DocumentFilter[];
+            },
+            wf
+        ) => {
+            const { disableLanguages } = getConfig(wf.uri);
+            let { languageSelector, rangeLanguageSelector } = ret;
+            const relativePattern = new RelativePattern(wf, '**');
+
+            languageSelector = languageSelector.concat(
+                allLanguages.filter(l => !disableLanguages.includes(l)).map(
+                    l =>
+                        ({
+                            language: l,
+                            pattern: relativePattern,
+                        } as DocumentFilter)
+                )
+            );
+            rangeLanguageSelector = rangeLanguageSelector.concat(
+                allRangeLanguages
+                    .filter(l => !disableLanguages.includes(l))
+                    .map(
+                        l =>
+                            ({
+                                language: l,
+                                pattern: relativePattern,
+                            } as DocumentFilter)
+                    )
+            );
+            return { languageSelector, rangeLanguageSelector };
+        },
+        { languageSelector: [], rangeLanguageSelector: [] }
+    );
+}
 
 export function activate(context: ExtensionContext) {
     const { fileIsIgnored } = ignoreFileHandler(context.subscriptions);
     const editProvider = new EditProvider(fileIsIgnored);
-    const languageSelector = allEnabledLanguages();
 
-    // Range selection is only supported for JS/TS
-    const rangeLanguageSelector = allJSLanguages();
-
+    const { languageSelector, rangeLanguageSelector } = selectors();
     context.subscriptions.push(
         languages.registerDocumentRangeFormattingEditProvider(
             rangeLanguageSelector,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,85 +5,123 @@ import {
     DocumentFilter,
     DocumentSelector,
     RelativePattern,
+    WorkspaceFolder,
+    Disposable,
 } from 'vscode';
 import EditProvider from './PrettierEditProvider';
 import { setupErrorHandler, registerDisposables } from './errorHandler';
 import { allEnabledLanguages, allJSLanguages, getConfig } from './utils';
 import configFileListener from './configCacheHandler';
 import ignoreFileHandler from './ignoreFileHandler';
-interface Selector {
+
+interface Selectors {
     rangeLanguageSelector: DocumentSelector;
     languageSelector: DocumentSelector;
 }
-function selectors(): Selector {
+
+let formatterHandler: undefined | Disposable;
+let rangeFormatterHandler: undefined | Disposable;
+function disposeHandlers() {
+    if (formatterHandler) {
+        formatterHandler.dispose();
+    }
+    if (rangeFormatterHandler) {
+        rangeFormatterHandler.dispose();
+    }
+    formatterHandler = undefined;
+    rangeFormatterHandler = undefined;
+}
+
+function selectorsCreator(wf: WorkspaceFolder) {
     const allLanguages = allEnabledLanguages();
     const allRangeLanguages = allJSLanguages();
+    const { disableLanguages } = getConfig(wf.uri);
+    const relativePattern = new RelativePattern(wf, '**');
+    function docFilterForLangs(languages: string[]) {
+        return languages.filter(l => !disableLanguages.includes(l)).map(
+            l =>
+                ({
+                    language: l,
+                    pattern: relativePattern,
+                } as DocumentFilter)
+        );
+    }
+    const languageSelector = docFilterForLangs(allLanguages);
+
+    const rangeLanguageSelector = docFilterForLangs(allRangeLanguages);
+
+    return { languageSelector, rangeLanguageSelector };
+}
+
+function selectors(): Selectors {
+    const allLanguages = allEnabledLanguages();
+    const allRangeLanguages = allJSLanguages();
+    const { disableLanguages } = getConfig();
+    const globalLanguageSelector = allLanguages.filter(
+        l => !disableLanguages.includes(l)
+    );
+    const globalRangeLanguageSelector = allRangeLanguages.filter(
+        l => !disableLanguages.includes(l)
+    );
     if (workspace.workspaceFolders === undefined) {
         // no workspace opened
-        const { disableLanguages } = getConfig();
-        const languageSelector = allLanguages.filter(
-            l => !disableLanguages.includes(l)
-        );
-        const rangeLanguageSelector = allRangeLanguages.filter(
-            l => !disableLanguages.includes(l)
-        );
-        return { languageSelector, rangeLanguageSelector };
+        return {
+            languageSelector: globalLanguageSelector,
+            rangeLanguageSelector: globalRangeLanguageSelector,
+        };
     }
-    // at least 1 workspace
 
-    // TODO: untitled files to concat.
+    // at least 1 workspace
+    const untitledLanguageSelector: DocumentFilter[] = globalLanguageSelector.map(
+        l => ({ language: l, scheme: 'untitled' })
+    );
+    const untitledRangeLanguageSelector: DocumentFilter[] = globalRangeLanguageSelector.map(
+        l => ({ language: l, scheme: 'untitled' })
+    );
     return workspace.workspaceFolders.reduce(
         (
-            ret: {
-                languageSelector: DocumentFilter[];
-                rangeLanguageSelector: DocumentFilter[];
-            },
-            wf
+            previous,
+            workspaceFolder
         ) => {
-            const { disableLanguages } = getConfig(wf.uri);
-            let { languageSelector, rangeLanguageSelector } = ret;
-            const relativePattern = new RelativePattern(wf, '**');
-
-            languageSelector = languageSelector.concat(
-                allLanguages.filter(l => !disableLanguages.includes(l)).map(
-                    l =>
-                        ({
-                            language: l,
-                            pattern: relativePattern,
-                        } as DocumentFilter)
-                )
-            );
-            rangeLanguageSelector = rangeLanguageSelector.concat(
-                allRangeLanguages
-                    .filter(l => !disableLanguages.includes(l))
-                    .map(
-                        l =>
-                            ({
-                                language: l,
-                                pattern: relativePattern,
-                            } as DocumentFilter)
-                    )
-            );
-            return { languageSelector, rangeLanguageSelector };
+            let { languageSelector, rangeLanguageSelector } = previous;
+            const select = selectorsCreator(workspaceFolder);
+            return {
+                languageSelector: languageSelector.concat(
+                    select.languageSelector
+                ),
+                rangeLanguageSelector: rangeLanguageSelector.concat(
+                    select.rangeLanguageSelector
+                ),
+            };
         },
-        { languageSelector: [], rangeLanguageSelector: [] }
+        {
+            languageSelector: untitledLanguageSelector,
+            rangeLanguageSelector: untitledRangeLanguageSelector,
+        }
     );
 }
 
 export function activate(context: ExtensionContext) {
     const { fileIsIgnored } = ignoreFileHandler(context.subscriptions);
     const editProvider = new EditProvider(fileIsIgnored);
-
-    const { languageSelector, rangeLanguageSelector } = selectors();
-    context.subscriptions.push(
-        languages.registerDocumentRangeFormattingEditProvider(
+    function registerFormatter() {
+        disposeHandlers();
+        const { languageSelector, rangeLanguageSelector } = selectors();
+        formatterHandler = languages.registerDocumentRangeFormattingEditProvider(
             rangeLanguageSelector,
             editProvider
-        ),
-        languages.registerDocumentFormattingEditProvider(
+        );
+        rangeFormatterHandler = languages.registerDocumentFormattingEditProvider(
             languageSelector,
             editProvider
-        ),
+        );
+    }
+    registerFormatter();
+    context.subscriptions.push(
+        workspace.onDidChangeWorkspaceFolders(registerFormatter),
+        {
+            dispose: disposeHandlers,
+        },
         setupErrorHandler(),
         configFileListener(),
         ...registerDisposables()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { workspace, DocumentSelector, Uri } from 'vscode';
+import { workspace, Uri } from 'vscode';
 import {
     PrettierVSCodeConfig,
     Prettier,
@@ -23,14 +23,14 @@ export function getParsersFromLanguageId(
     return language.parsers;
 }
 
-export function allEnabledLanguages(): DocumentSelector {
+export function allEnabledLanguages(): string[] {
     return getSupportLanguages().reduce(
         (ids, language) => [...ids, ...language.vscodeLanguageIds],
         [] as string[]
     );
 }
 
-export function allJSLanguages(): DocumentSelector {
+export function allJSLanguages(): string[] {
     return getGroup('JavaScript')
         .filter(language => language.group === 'JavaScript')
         .reduce(

--- a/test/disabled.test.ts
+++ b/test/disabled.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert';
+import { format } from './format.test';
+import { workspace } from 'vscode';
+import { Prettier } from '../src/types';
+
+const prettier = require('prettier') as Prettier;
+
+suite('Test disabled', function() {
+    test('it formats with default formatter', () => {
+        return format('disable.js', workspace.workspaceFolders![1].uri).then(
+            ({ result, source }) => {
+                assert.notEqual(result, source); // it as been formatted.
+                const prettierFormatted = prettier.format(source, {
+                    parser: 'babylon',
+                });
+                assert.notEqual(result, prettierFormatted); // but not with prettier
+            }
+        );
+    });
+});

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { Prettier, ParserOption } from '../src/types';
+import { Uri } from 'vscode';
 const prettier = require('prettier') as Prettier;
 // import * as PrettierVSCode from '../src/extension';
 
@@ -12,12 +13,13 @@ const EXT_PARSER: { [ext: string]: ParserOption } = {
 };
 /**
  * loads and format a file.
- * @param file path relative to workspace root
+ * @param file path relative to base URI (a workspaceFolder's URI)
+ * @param base base URI
  * @returns source code and resulting code
  */
-export function format(file: string) {
+export function format(file: string, base: Uri = vscode.workspace.workspaceFolders![0].uri) {
     const absPath = path.join(
-        vscode.workspace.rootPath! /* Test are run in a workspace */,
+        base.fsPath,
         file
     );
     return vscode.workspace.openTextDocument(absPath).then(doc => {

--- a/testProject/.vscode/settings.json
+++ b/testProject/.vscode/settings.json
@@ -9,23 +9,5 @@
     "prettier.parser": "babylon",
     "prettier.semi": true,
     "prettier.useTabs": false,
-    "prettier.javascriptEnable": [
-        "javascript",
-        "javascriptreact"
-    ],
-    "prettier.typescriptEnable": [
-        "typescript",
-        "typescriptreact"
-    ],
-    "prettier.cssEnable": [
-        "css",
-        "less",
-        "scss"
-    ],
-    "prettier.jsonEnable": [
-        "json"
-    ],
-    "prettier.graphqlEnable": [
-        "graphql"
-    ]
+    "prettier.disableLanguages": []
 }

--- a/testWorkspace.code-workspace
+++ b/testWorkspace.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "testProject"
+		},
+		{
+			"path": "testWorkspaceFolder"
+		}
+	],
+	"settings": {}
+}

--- a/testWorkspaceFolder/.vscode/settings.json
+++ b/testWorkspaceFolder/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "prettier.disableLanguages": [
+        "javascript"
+    ],
+    "javascript.format.enable": true
+}

--- a/testWorkspaceFolder/disable.js
+++ b/testWorkspaceFolder/disable.js
@@ -1,0 +1,7 @@
+// this should be formatted with default formatter. It doesn't collapse linebreaks.
+function formattedWithDefault   (  )   {
+
+
+    
+    
+}


### PR DESCRIPTION
Status: Ready

TODO:
- [x] Handle untitled files (not persisted)
- [x] Update formatter registration on workspace folder add / remove
- [x] Tests
- [x] ~Certainly some refactor (use a map or 2 `workspaceFolder -> languageSelector`)~ Keep it simple. Recompute everything.
- [x] Changelog
- [x] Readme. It will certainly need a restart required. Or recompute on config change.
- [x] ~Add logging to output panel with enabled language. Should be easier for users to know which language they may disable.~ We should have something like a debug log with more than just that.

fix #272   