### PR TITLE
Update Prettier to 1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,9 +3333,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
-      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg=="
     },
     "prettier-eslint": {
       "version": "8.3.1",
@@ -3348,7 +3348,7 @@
         "indent-string": "3.2.0",
         "lodash.merge": "4.6.0",
         "loglevel-colored-level-prefix": "1.0.0",
-        "prettier": "1.9.2",
+        "prettier": "1.10.2",
         "pretty-format": "21.2.1",
         "require-relative": "0.8.7",
         "typescript": "2.6.2",
@@ -3368,7 +3368,7 @@
         "import-local": "0.1.1",
         "meow": "3.7.0",
         "pify": "3.0.0",
-        "prettier": "1.9.2",
+        "prettier": "1.10.2",
         "resolve-from": "4.0.0",
         "stylelint": "8.2.0",
         "temp-write": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
   },
   "dependencies": {
     "ignore": "^3.3.7",
-    "prettier": "1.9.2",
+    "prettier": "1.10.2",
     "prettier-eslint": "^8.3.1",
     "prettier-stylelint": "^0.4.1",
     "read-pkg-up": "2.0.0"


### PR DESCRIPTION
Was desperately waiting for this for getting formatting on JSON-with-comments (https://github.com/prettier/prettier/pull/3496)

On a sidenote, what about something like Greenkeeper or Renovate to automate this?

Edit @CiGit: fix #325