### PR TITLE
Misleading link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VS Code package to format your JavaScript / TypeScript / CSS using [Prettier](ht
 
 Install through VS Code extensions. Search for `Prettier - Code formatter`
 
-[Visual Studio Code Market Place: Prettier - JavaScript formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+[Visual Studio Code Market Place: Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 
 Can also be installed using
 


### PR DESCRIPTION
Due to the following fact:
- ```ext install prettier-vscode``` has "Prettier - JavaScript Formatter" by Mathieu SCHROETER and more as top hits.
- The link to Prettier - Code Formatter has the text "Prettier - JavaScript formatter".

I picked a different formatter than the one linked to.