### PR TITLE
Prettier silently doesn't work when wrong ignore path provided (Windows 10)

### DIFF
--- a/src/ignoreFileHandler.ts
+++ b/src/ignoreFileHandler.ts
@@ -84,6 +84,9 @@ function getIgnorePathForFile(
     if (!ignorePath) {
         return null;
     }
+    if (!existsSync(ignorePath)) {
+        return null;
+    }
     if (workspace.workspaceFolders) {
         const folder = workspace.getWorkspaceFolder(Uri.file(filePath));
         return folder ? getPath(ignorePath, folder.uri.fsPath) : null;

--- a/src/ignoreFileHandler.ts
+++ b/src/ignoreFileHandler.ts
@@ -86,7 +86,7 @@ function getIgnorePathForFile(
         return null;
     }
     if (!existsSync(ignorePath)) {
-        addToOutput("Wrong prettier.ignorePath provided in your User or Workspace Settings. The path does not exist.");
+        addToOutput(`Wrong prettier.ignorePath provided in your settings. The path (${ignorePath}) does not exist.`);
         return null;
     }
     if (workspace.workspaceFolders) {

--- a/src/ignoreFileHandler.ts
+++ b/src/ignoreFileHandler.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import { workspace, Uri, Disposable } from 'vscode';
 import { getConfig } from './utils';
+import { addToOutput } from './errorHandler';
 
 const ignore = require('ignore');
 
@@ -85,6 +86,7 @@ function getIgnorePathForFile(
         return null;
     }
     if (!existsSync(ignorePath)) {
+        addToOutput("Wrong prettier.ignorePath provided in your User or Workspace Settings. The path does not exist.");
         return null;
     }
     if (workspace.workspaceFolders) {


### PR DESCRIPTION
![error image](https://i.imgur.com/q0lkeyj.png)

When provided with a wrong "prettier.ignorePath", Prettier will simply never get that little tick in the bottom right corner and will completely fail (as shown on the screenshot attached).

As you can see the error throws:
> Cannot read property 'ignores' of undefined: TypeError: Cannot read property 'ignores' of 

This is due to the fact that is trying to read the path that doesn't really exist.

It took me like 2 hours to debug this thanks to the Developer: Startup Performance feature, otherwise, there's no way I would have fixed it.

The simple solution is to simply check if the directory exists and if not, return null.

Better solution for this whatsoever to somehow inform the user that the ignore path he or she used is wrong. 

