### PR TITLE
Adding initial support for Visual Studio Live Share

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -43,6 +43,7 @@ async function resolveConfig(filePath: string, options?: { editorconfig?: boolea
     try {
         return await bundledPrettier.resolveConfig(filePath, options);
     } catch (e) {
+        addToOutput(`Failed to resolve config for ${filePath}. Falling back to the default config settings.`);
         return null;
     }
  }
@@ -124,9 +125,10 @@ async function format(
     if (!hasConfig && vscodeConfig.requireConfig) {
         return text;
     }
-    const fileOptions = await resolveConfig(fileName, {
+
+    const fileOptions = (hasConfig ? await resolveConfig(fileName, {
         editorconfig: true,
-    }) || {};
+    }) : null) || {};
 
     const prettierOptions = mergeConfig(hasConfig, customOptions, fileOptions, {
         printWidth: vscodeConfig.printWidth,

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -31,8 +31,8 @@ const STYLE_PARSERS: ParserOption[] = ['postcss', 'css', 'less', 'scss'];
  * @param filePath file's path
  */
 async function hasPrettierConfig(filePath: string) {
-    const { config } = await resolveConfig(filePath);
-    return config !== null;
+    const { error } = await resolveConfig(filePath);
+    return error == null;
 }
 
 type ResolveConfigResult = { config: Partial<PrettierConfig>, error?: Error };

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -31,8 +31,21 @@ const STYLE_PARSERS: ParserOption[] = ['postcss', 'css', 'less', 'scss'];
  * @param filePath file's path
  */
 async function hasPrettierConfig(filePath: string) {
-    return (await bundledPrettier.resolveConfig(filePath)) !== null;
+    return (await resolveConfig(filePath)) !== null;
 }
+
+/**
+ * Resolves the prettierconfig for the given file.
+ * 
+ * @param filePath file's path
+ */
+async function resolveConfig(filePath: string, options?: { editorconfig?: boolean }): Promise<PrettierConfig | null> {
+    try {
+        return await bundledPrettier.resolveConfig(filePath, options);
+    } catch (e) {
+        return null;
+    }
+ }
 
 /**
  * Define which config should be used.
@@ -111,9 +124,9 @@ async function format(
     if (!hasConfig && vscodeConfig.requireConfig) {
         return text;
     }
-    const fileOptions = await bundledPrettier.resolveConfig(fileName, {
+    const fileOptions = await resolveConfig(fileName, {
         editorconfig: true,
-    });
+    }) || {};
 
     const prettierOptions = mergeConfig(hasConfig, customOptions, fileOptions, {
         printWidth: vscodeConfig.printWidth,

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -31,11 +31,11 @@ const STYLE_PARSERS: ParserOption[] = ['postcss', 'css', 'less', 'scss'];
  * @param filePath file's path
  */
 async function hasPrettierConfig(filePath: string) {
-    const { error } = await resolveConfig(filePath);
-    return error == null;
+    const { config } = await resolveConfig(filePath);
+    return config !== null;
 }
 
-type ResolveConfigResult = { config: Partial<PrettierConfig>, error?: Error };
+type ResolveConfigResult = { config: PrettierConfig | null, error?: Error };
 
 /**
  * Resolves the prettierconfig for the given file.
@@ -47,7 +47,7 @@ async function resolveConfig(filePath: string, options?: { editorconfig?: boolea
         const config = await bundledPrettier.resolveConfig(filePath, options);
         return { config };
     } catch (error) {
-        return { config: {}, error };
+        return { config: null, error };
     }
  }
 
@@ -137,7 +137,7 @@ async function format(
         addToOutput(`Failed to resolve config for ${fileName}. Falling back to the default config settings.`);
     }
 
-    const prettierOptions = mergeConfig(hasConfig, customOptions, fileOptions, {
+    const prettierOptions = mergeConfig(hasConfig, customOptions, fileOptions || {}, {
         printWidth: vscodeConfig.printWidth,
         tabWidth: vscodeConfig.tabWidth,
         singleQuote: vscodeConfig.singleQuote,


### PR DESCRIPTION
This PR adds initial support for [Visual Studio Live Share](http://aka.ms/vsls), which will allow developers who have installed this extension, to continue using Prettier while collaborating on someone else's project (e.g. pair programming). Without this change, if the "guest" in a collaboration session tried to format a range or document, they would get the inbox VS Code formatting behavior, which could be a little confusing, and definitely not as awesome 🚀 

Prettier's `resolveConfig` method throws an exception if it can't enumerate the workspace directories, which in the case of a "guest" in a Live Share session, wouldn't exist, since they've viewing/editing remote files that aren't downloaded locally. 

Long-term, it would be ideal if this extension could use a VS Code-specific API to resolve the app's actual config, using the virtual file system that Visual Studio Live Share exposes (the `vsls:` scheme). With this change, the Live Share "guest" would be able to format, but it wouldn't respect any Prettier config that the app might have. For now though, this PR unblocks the basic scenario of being able to format, for apps that are simply using the default Prettier config.

EDIT @cigit:
 - fix #366