### PR TITLE
[Discussion] [Live Share] Restricting workspace formatting to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,7 @@ function selectorsCreator(wf: WorkspaceFolder) {
                 ({
                     language: l,
                     pattern: relativePattern,
+                    scheme: 'file'
                 } as DocumentFilter)
         );
     }


### PR DESCRIPTION
As a continuation of #378, this PR simply updates the existing workspace `DocumentSelector`, so that it only applies to `file:`-based, and `untitled` (unsaved) documents. In the case of Visual Studio Live Share, a "guest" would see documents using the `vsls:` scheme, and would therefore "remote" the formatting request to the "host" as opposed to trying to run Prettier locally. However, this change wouldn't impact the "traditional" use of Prettier.