### PR TITLE
add an error message popup when prettier fails to format

### DIFF
--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -15,9 +15,21 @@ let statusBarItem: StatusBarItem;
 let outputChannel: OutputChannel;
 let prettierInformation: string;
 
+function showPrettierErrorMessage() {
+    const showErrorAction = 'Show error';
+
+    window
+        .showErrorMessage('Prettier failed to format!', showErrorAction)
+        .then(action => {
+            if (action === showErrorAction) {
+                commands.executeCommand('prettier.open-output');
+            }
+        });
+}
+
 function toggleStatusBarItem(editor: TextEditor | undefined): void {
     if (editor !== undefined) {
-        // The function will be triggered everytime the active "editor" instance changes
+        // The function will be triggered every time the active "editor" instance changes
         // It also triggers when we focus on the output panel or on the debug panel
         // Both are seen as an "editor".
         // The following check will ignore such panels
@@ -130,6 +142,7 @@ export function safeExecution(
             .catch((err: Error) => {
                 addToOutput(addFilePath(err.message, fileName));
                 updateStatusBar('Prettier: $(x)');
+                showPrettierErrorMessage();
 
                 return defaultText;
             });
@@ -143,6 +156,7 @@ export function safeExecution(
     } catch (err) {
         addToOutput(addFilePath(err.message, fileName));
         updateStatusBar('Prettier: $(x)');
+        showPrettierErrorMessage();
 
         return defaultText;
     }

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -18,16 +18,13 @@ let prettierInformation: string;
 function showPrettierErrorMessage(message: string = 'failed to format!') {
     const showErrorAction = 'More';
 
-    // Prefix the message with Prettier so that the user knows which extension it is
-    const fullMessage = `Prettier: ${message}`;
-
     const maxMessageLength = 60;
 
     // Truncate the message so that we don't show huge blocks of source code
     const actualMessage =
-        fullMessage.length <= maxMessageLength
-            ? fullMessage
-            : fullMessage.substr(0, maxMessageLength - 3) + '...';
+        message.length <= maxMessageLength
+            ? message
+            : message.substr(0, maxMessageLength - 3) + '...';
 
     window.showErrorMessage(actualMessage, showErrorAction).then(action => {
         if (action === showErrorAction) {


### PR DESCRIPTION
This PR will add an error popup when prettier fails to format. In earlier version we also had this feature but the popups were at the top and very intrusive.

Now with the new notifications they appear in a corner and are not taking over focus. When you press the <kbd>esc</kbd> key, they are dismissed.

The notifications also has a `Show error` button which will open the output panel when triggered. This will show the full error.

Note: I tried putting the error inside the notification directly, but it removed all new lines resulting in the output code to be a one liner, unreadable.

Feel free to discuss options or try this feature out!

It will solve the following issues: #393

An example of the popup:

![](http://d.rbn.nu/tjVZLT.png)