### PR TITLE
Prefer local `prettier-eslint` over bundled version

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -154,7 +154,7 @@ async function format(
     if (vscodeConfig.eslintIntegration && doesParserSupportEslint) {
         return safeExecution(
             () => {
-                const prettierEslint = require('prettier-eslint') as PrettierEslintFormat;
+                const prettierEslint = requireLocalPkg(fileName, 'prettier-eslint') as PrettierEslintFormat;
                 setUsedModule('prettier-eslint', 'Unknown', true);
 
                 return prettierEslint({


### PR DESCRIPTION
The bundled version of `prettier-eslint` [does not support `.mjs` files](https://github.com/prettier/prettier-eslint/pull/173), so I had to use my fork. However, this extension uses the bundled version of `prettier-eslint` instead of the local version installed in the project.

This PR fixes it. :)