### PR TITLE
Add an option to toggle error messages off

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Require a 'prettierconfig' to format
 Supply the path to an ignore file such as `.gitignore` or `.prettierignore`.
 Files which match will not be formatted. Set to `null` to not read ignore files. Restart required.
 
+#### prettier.showErrorMessages (default: true)
+Displays an error message popup when prettier fails to format.
+
 #### prettier.disableLanguages (default: ["vue"])
 A list of languages IDs to disable this extension on. Restart required.
 *Note: Disabling a language enabled in a parent folder will prevent formatting instead of letting any other formatter to run*

--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
           "description": "Path to a .prettierignore or similar file",
           "scope": "resource"
         },
+        "prettier.showErrorMessages": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show error message popups when prettier fails to format",
+          "scope": "resource"
+        },
         "prettier.printWidth": {
           "type": "integer",
           "default": 80,

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -9,13 +9,15 @@ import {
     languages,
 } from 'vscode';
 
-import { allEnabledLanguages } from './utils';
+import { allEnabledLanguages, getConfig } from './utils';
 
 let statusBarItem: StatusBarItem;
 let outputChannel: OutputChannel;
 let prettierInformation: string;
 
 function showPrettierErrorMessage(message: string = 'failed to format!') {
+    if (!getConfig().showErrorMessages) return;
+
     const showErrorAction = 'More';
 
     const maxMessageLength = 60;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,6 +74,10 @@ interface ExtensionConfig {
      * Array of language IDs to ignore
      */
     disableLanguages: string[];
+    /**
+     * If true will show error message popup when prettier fails to format
+     */
+    showErrorMessages: boolean;
 }
 
 /**


### PR DESCRIPTION
This adds a setting to disable the error messages introduced by https://github.com/prettier/prettier-vscode/commit/ce62204e52b41064b195d9346cd588bea264eb46, closing https://github.com/prettier/prettier-vscode/issues/481.

I've neither written a line of typescript in my life nor worked on a vscode extension so if there's a more idiomatic way to do this (or I've broken something) I'd be happy to make changes, just need some guidance— many of us find these popups pretty frustrating 😢

I suspect I'm supposed to be passing a uri into `getConfig` but could not figure out what that would be.