### PR TITLE
Parser inference also based on filename and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 ## [Unreleased]
 
 -   Revert notification popup: remove it.
+-   fix parser inference
 
 ## [1.4.0]
 

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -35,21 +35,24 @@ async function hasPrettierConfig(filePath: string) {
     return config !== null;
 }
 
-type ResolveConfigResult = { config: PrettierConfig | null, error?: Error };
+type ResolveConfigResult = { config: PrettierConfig | null; error?: Error };
 
 /**
  * Resolves the prettierconfig for the given file.
- * 
+ *
  * @param filePath file's path
  */
-async function resolveConfig(filePath: string, options?: { editorconfig?: boolean }): Promise<ResolveConfigResult> {
+async function resolveConfig(
+    filePath: string,
+    options?: { editorconfig?: boolean }
+): Promise<ResolveConfigResult> {
     try {
         const config = await bundledPrettier.resolveConfig(filePath, options);
         return { config };
     } catch (error) {
         return { config: null, error };
     }
- }
+}
 
 /**
  * Define which config should be used.
@@ -86,7 +89,7 @@ function mergeConfig(
  */
 async function format(
     text: string,
-    { fileName, languageId, uri }: TextDocument,
+    { fileName, languageId, uri, isUntitled }: TextDocument,
     customOptions: Partial<PrettierConfig>
 ): Promise<string> {
     const vscodeConfig: PrettierVSCodeConfig = getConfig(uri);
@@ -101,7 +104,8 @@ async function format(
 
     const dynamicParsers = getParsersFromLanguageId(
         languageId,
-        localPrettier.version
+        localPrettier.version,
+        isUntitled ? undefined : fileName
     );
     let useBundled = false;
     let parser: ParserOption;
@@ -109,7 +113,8 @@ async function format(
     if (!dynamicParsers.length) {
         const bundledParsers = getParsersFromLanguageId(
             languageId,
-            bundledPrettier.version
+            bundledPrettier.version,
+            isUntitled ? undefined : fileName
         );
         parser = bundledParsers[0] || 'babylon';
         useBundled = true;
@@ -134,22 +139,29 @@ async function format(
     });
 
     if (error) {
-        addToOutput(`Failed to resolve config for ${fileName}. Falling back to the default config settings.`);
+        addToOutput(
+            `Failed to resolve config for ${fileName}. Falling back to the default config settings.`
+        );
     }
 
-    const prettierOptions = mergeConfig(hasConfig, customOptions, fileOptions || {}, {
-        printWidth: vscodeConfig.printWidth,
-        tabWidth: vscodeConfig.tabWidth,
-        singleQuote: vscodeConfig.singleQuote,
-        trailingComma: vscodeConfig.trailingComma,
-        bracketSpacing: vscodeConfig.bracketSpacing,
-        jsxBracketSameLine: vscodeConfig.jsxBracketSameLine,
-        parser: parser,
-        semi: vscodeConfig.semi,
-        useTabs: vscodeConfig.useTabs,
-        proseWrap: vscodeConfig.proseWrap,
-        arrowParens: vscodeConfig.arrowParens,
-    });
+    const prettierOptions = mergeConfig(
+        hasConfig,
+        customOptions,
+        fileOptions || {},
+        {
+            printWidth: vscodeConfig.printWidth,
+            tabWidth: vscodeConfig.tabWidth,
+            singleQuote: vscodeConfig.singleQuote,
+            trailingComma: vscodeConfig.trailingComma,
+            bracketSpacing: vscodeConfig.bracketSpacing,
+            jsxBracketSameLine: vscodeConfig.jsxBracketSameLine,
+            parser: parser,
+            semi: vscodeConfig.semi,
+            useTabs: vscodeConfig.useTabs,
+            proseWrap: vscodeConfig.proseWrap,
+            arrowParens: vscodeConfig.arrowParens,
+        }
+    );
 
     if (vscodeConfig.eslintIntegration && doesParserSupportEslint) {
         return safeExecution(
@@ -218,7 +230,8 @@ function fullDocumentRange(document: TextDocument): Range {
 }
 
 class PrettierEditProvider
-    implements DocumentRangeFormattingEditProvider,
+    implements
+        DocumentRangeFormattingEditProvider,
         DocumentFormattingEditProvider {
     constructor(private _fileIsIgnored: (filePath: string) => boolean) {}
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,6 +7,7 @@ export type ParserOption =
     | 'scss'
     | 'typescript'
     | 'json'
+    | 'json-stringify'
     | 'graphql'
     | 'markdown';
 
@@ -47,6 +48,7 @@ export interface PrettierConfig {
     arrowParens: 'avoid' | 'always';
     rangeStart: number;
     rangeEnd: number;
+    filepath: string;
 }
 /**
  * prettier-vscode specific configuration

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { workspace, Uri } from 'vscode';
+import { basename } from 'path';
 import {
     PrettierVSCodeConfig,
     Prettier,
@@ -12,10 +13,17 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
 
 export function getParsersFromLanguageId(
     languageId: string,
-    version: string
+    version: string,
+    path?: string
 ): ParserOption[] {
-    const language = getSupportLanguages().find(lang =>
-        lang.vscodeLanguageIds.includes(languageId)
+    const language = getSupportLanguages(version).find(
+        lang =>
+            lang.vscodeLanguageIds.includes(languageId) &&
+            // Only for some specific filenames
+            (lang.extensions.length > 0 ||
+                (path != null &&
+                    lang.filenames != null &&
+                    lang.filenames.includes(basename(path))))
     );
     if (!language) {
         return [];
@@ -43,6 +51,6 @@ export function getGroup(group: string): PrettierSupportInfo['languages'] {
     return getSupportLanguages().filter(language => language.group === group);
 }
 
-function getSupportLanguages() {
-    return (require('prettier') as Prettier).getSupportInfo().languages;
+function getSupportLanguages(version?: string) {
+    return (require('prettier') as Prettier).getSupportInfo(version).languages;
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,27 +1,21 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { Prettier, ParserOption } from '../src/types';
+import { Prettier } from '../src/types';
 import { Uri } from 'vscode';
 const prettier = require('prettier') as Prettier;
-// import * as PrettierVSCode from '../src/extension';
 
-const EXT_PARSER: { [ext: string]: ParserOption } = {
-    css: 'css',
-    json: 'json',
-    ts: 'typescript',
-};
 /**
  * loads and format a file.
  * @param file path relative to base URI (a workspaceFolder's URI)
  * @param base base URI
  * @returns source code and resulting code
  */
-export function format(file: string, base: Uri = vscode.workspace.workspaceFolders![0].uri) {
-    const absPath = path.join(
-        base.fsPath,
-        file
-    );
+export function format(
+    file: string,
+    base: Uri = vscode.workspace.workspaceFolders![0].uri
+) {
+    const absPath = path.join(base.fsPath, file);
     return vscode.workspace.openTextDocument(absPath).then(doc => {
         const text = doc.getText();
         return vscode.window.showTextDocument(doc).then(
@@ -46,7 +40,7 @@ export function format(file: string, base: Uri = vscode.workspace.workspaceFolde
 function formatSameAsPrettier(file: string) {
     return format(file).then(result => {
         const prettierFormatted = prettier.format(result.source, {
-            parser: EXT_PARSER[path.extname(file).slice(1)] || 'babylon',
+            filepath: file,
         });
         assert.equal(result.result, prettierFormatted);
     });
@@ -59,6 +53,7 @@ suite('Test format Document', function() {
         formatSameAsPrettier('formatTest/ugly.ts'));
     test('it formats CSS', () => formatSameAsPrettier('formatTest/ugly.css'));
     test('it formats JSON', () => formatSameAsPrettier('formatTest/ugly.json'));
+    test('it formats JSON', () => formatSameAsPrettier('formatTest/package.json'));
     // one would need to register that language for it to work ...
     // test('it formats GraphQL', () => {
     //     return;

--- a/testProject/formatTest/package.json
+++ b/testProject/formatTest/package.json
@@ -1,0 +1,8 @@
+{
+    "name": 
+    "this-is-a-lie",
+    "description": "Just testing formating of specific file name. In this case a 'package.json' file",
+    
+    
+    "private":    true
+}


### PR DESCRIPTION
Infer parser by taking into account version and filename.

Change tests, let prettier infer the parser based on filename.
Fix #483 