### PR TITLE
Add 'mongo' as supported language

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,7 @@ export function rangeSupportedLanguages(): string[] {
         'typescriptreact',
         'json',
         'graphql',
+        'mongo',
     ];
 }
 


### PR DESCRIPTION
As the title said. We normally write mongo query like either javascript or json, so prettier will parse and format just right.
Great for formatting cosmos scrapbook too