### PR TITLE
Add syntax for .prettierignore file

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,12 @@
         "filenames": [
           ".prettierrc"
         ]
+      },
+      {
+        "id": "ignore",
+        "filenames": [
+          ".prettierignore"
+        ]
       }
     ]
   },


### PR DESCRIPTION
Recently VSCode added a language for ignore files. It doesn't really do much but it marks lines starting with # as comments and makes them togglable with cmd+/.