### PR TITLE
Bumps prettier to version 1.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   },
   "dependencies": {
     "ignore": "^3.3.8",
-    "prettier": "1.14.2",
+    "prettier": "1.15.1",
     "prettier-eslint": "^8.8.1",
     "prettier-stylelint": "^0.4.2",
     "prettier-tslint": "^0.4.0",


### PR DESCRIPTION
A new major version was released today: https://prettier.io/blog/2018/11/07/1.15.0.html