### PR TITLE
Update Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
  - "8"


### PR DESCRIPTION
Hi,
Travis will be undergoing an infra upgrade and hence it is advised to remove `sudo: false` from travis-ci config. You can read more here https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration