### PR TITLE
Use local prettier instance for parsers

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -105,7 +105,7 @@ async function format(
 
     const dynamicParsers = getParsersFromLanguageId(
         languageId,
-        localPrettier.version,
+        localPrettier,
         isUntitled ? undefined : fileName
     );
     let useBundled = false;
@@ -114,7 +114,7 @@ async function format(
     if (!dynamicParsers.length) {
         const bundledParsers = getParsersFromLanguageId(
             languageId,
-            bundledPrettier.version,
+            bundledPrettier,
             isUntitled ? undefined : fileName
         );
         parser = bundledParsers[0] || 'babylon';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,16 +7,18 @@ import {
     ParserOption,
 } from './types.d';
 
+const bundledPrettier = require('prettier') as Prettier;
+
 export function getConfig(uri?: Uri): PrettierVSCodeConfig {
     return workspace.getConfiguration('prettier', uri) as any;
 }
 
 export function getParsersFromLanguageId(
     languageId: string,
-    version: string,
+    prettierInstance: Prettier,
     path?: string
 ): ParserOption[] {
-    const language = getSupportLanguages(version).find(
+    const language = getSupportLanguages(prettierInstance).find(
         lang =>
             Array.isArray(lang.vscodeLanguageIds) &&
             lang.vscodeLanguageIds.includes(languageId) &&
@@ -54,6 +56,6 @@ export function getGroup(group: string): PrettierSupportInfo['languages'] {
     return getSupportLanguages().filter(language => language.group === group);
 }
 
-function getSupportLanguages(version?: string) {
-    return (require('prettier') as Prettier).getSupportInfo(version).languages;
+function getSupportLanguages(prettierInstance: Prettier = bundledPrettier) {
+    return prettierInstance.getSupportInfo(prettierInstance.version).languages;
 }


### PR DESCRIPTION
Resolves https://github.com/prettier/prettier-vscode/issues/705

As part of 1.16.0 of Prettier, the parsers for each version were swapped from `babylon` to `babel`. However this causes the default parser to be used for any local version of Prettier to be `babel`, even if `babel` isn't a valid parser for that version.

This switches the dynamicParser interpretation to use the local version of Prettier, which will properly include `babylon` instead of `babel`, allowing the extension to run properly on local Prettier instances < 1.16.0 and avoid throwing `Couldn't resolve parser "babel"`

First time contributor, so please let me know if an alternative approach would be preferred, just hoping to get this fixed ASAP. (and avoid migrating a few hundred repos this week 😬).