### PR TITLE
Support Prettier <1.8.0 for getSupportInfo

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,5 +57,10 @@ export function getGroup(group: string): PrettierSupportInfo['languages'] {
 }
 
 function getSupportLanguages(prettierInstance: Prettier = bundledPrettier) {
-    return prettierInstance.getSupportInfo(prettierInstance.version).languages;
+    // prettier.getSupportInfo was added in prettier@1.8.0
+    if (prettierInstance.getSupportInfo) {
+        return prettierInstance.getSupportInfo(prettierInstance.version).languages;
+    } else {
+        return bundledPrettier.getSupportInfo(prettierInstance.version).languages;
+    }
 }


### PR DESCRIPTION
Quick followup to https://github.com/prettier/prettier-vscode/pull/706#discussion_r252837934

Connected to https://github.com/prettier/prettier-vscode/issues/710

This adds a fallback to `bundledPrettier.getSupportInfo` if `prettierInstance.getSupportInfo` is undefined. Currently this will still have the `babel` / `babylon` parser issue of https://github.com/prettier/prettier-vscode/issues/705, but this will be necessary once that's fixed upstream.