### PR TITLE
Add plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ You can turn on format-on-save on a per-language basis by scoping the setting:
 
 ### Prettier Plugins
 
-Prettier plugins are supported when using a local Prettier installation. Just install the plugin you need locally to your project, restart vscode and you are good to go.
+Prettier plugins are supported when using a custom Prettier installation local or global. The plugins must be installed to the corresponding installation.
+
+Eg. if you have installed Prettier locally to your project with `npm install --save-dev prettier` you must install the plugins like it too `npm install --save-dev @prettier/plugin-php`.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ You can turn on format-on-save on a per-language basis by scoping the setting:
 
 `eslint`, `tslint`, and all peer dependencies required by your specific configuration must be installed locally.  Global installations will not be recognized.
 
+### Prettier Plugins
+
+Prettier plugins are supported when using a local Prettier installation. Just install the plugin you need locally to your project, restart vscode and you are good to go.
+
 ## Settings
 
 ### Prettier's Settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -3371,6 +3371,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
+    "nested-error-stacks": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
+      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -4536,6 +4541,26 @@
       "requires": {
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
+      }
+    },
+    "requireg": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.1.tgz",
+      "integrity": "sha512-bbNOK9MAyAGe4Q9/0skx6bzkFVRvVuHerXZthc3jmf2/cO7gthKM7GpnhW522Vx3/uCLA9RXXpQaqdXHRrZVxQ==",
+      "requires": {
+        "nested-error-stacks": "~2.0.1",
+        "rc": "~1.2.7",
+        "resolve": "~1.7.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
       }
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "prettier-stylelint": "^0.4.2",
     "prettier-tslint": "^0.4.2",
     "read-pkg-up": "^4.0.0",
+    "requireg": "^0.2.1",
     "resolve": "^1.10.0",
     "typescript": "^2.9.2"
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
   "icon": "icon.png",
   "main": "./out/src/extension",
   "contributes": {
+    "commands": [
+      {
+       	"title": "Show Output Channel",
+        "category": "Prettier",
+        "command": "prettier.open-output"
+      }
+
+    ],
     "configuration": {
       "type": "object",
       "title": "Prettier - Code formatter configuration",

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -121,7 +121,6 @@ async function format(
     customOptions: Partial<PrettierConfig>
 ): Promise<string> {
     const vscodeConfig: PrettierVSCodeConfig = getConfig(uri);
-    const prettierInstance = getPrettierForFile(fileName);
 
     // This has to stay, as it allows to skip in sub workspaceFolders. Sadly noop.
     // wf1  (with "lang") -> glob: "wf1/**"
@@ -129,6 +128,8 @@ async function format(
     if (vscodeConfig.disableLanguages.includes(languageId)) {
         return text;
     }
+
+    const prettierInstance = getPrettierForFile(fileName);
 
     if (!supportsLanguage(languageId, prettierInstance)) {
         window.showErrorMessage(

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -95,19 +95,23 @@ function getPrettierForFile(
     // First try to use the local prettier for this file
     const local = requireLocalPkg<Prettier>(fileName, 'prettier');
     if (local) {
-        addToOutput('Formatting with local prettier');
+        addToOutput('Formatting with local prettier version ' + local.version);
         return { type: 'local', prettierInstance: local };
     }
 
     // Fallback to global if no local is found
     const global = requireGlobalPrettier();
     if (global) {
-        addToOutput('Formatting with global prettier');
+        addToOutput(
+            'Formatting with global prettier version ' + global.version
+        );
         return { type: 'global', prettierInstance: global };
     }
 
     // Finally use the bundled one if all else fail
-    addToOutput('Formatting with bundled prettier');
+    addToOutput(
+        'Formatting with bundled prettier version ' + bundledPrettier.version
+    );
     return { type: 'bundled', prettierInstance: bundledPrettier };
 }
 

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -6,10 +6,11 @@ import {
     FormattingOptions,
     CancellationToken,
     TextEdit,
+    window,
 } from 'vscode';
 
 import { safeExecution, addToOutput, setUsedModule } from './errorHandler';
-import { getParsersFromLanguageId, getConfig } from './utils';
+import { getParsersFromLanguageId, getConfig, supportsLanguage } from './utils';
 import { requireLocalPkg } from './requirePkg';
 
 import {
@@ -100,6 +101,13 @@ async function format(
     // wf1  (with "lang") -> glob: "wf1/**"
     // wf1/wf2  (without "lang") -> match "wf1/**"
     if (vscodeConfig.disableLanguages.includes(languageId)) {
+        return text;
+    }
+
+    if (!supportsLanguage(languageId, localPrettier)) {
+        window.showErrorMessage(
+            `Prettier does not support "${languageId}". Maybe a plugin is missing from the workspace?`
+        );
         return text;
     }
 

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -93,19 +93,19 @@ function getPrettierForFile(fileName: string): Prettier {
     // First try to use the local prettier for this file
     const local = requireLocalPkg<Prettier>(fileName, 'prettier');
     if (local) {
-        console.log('Formatting with local prettier');
+        console.log('prettier: Formatting with local prettier');
         return local;
     }
 
     // Fallback to global if no local is found
     const global = requireGlobalPrettier();
     if (global) {
-        console.log('Formatting with global prettier');
+        console.log('prettier: Formatting with global prettier');
         return global;
     }
 
     // Finally use the bundled one if all else fail
-    console.log('Formatting with bundled prettier');
+    console.log('prettier: Formatting with bundled prettier');
     return bundledPrettier;
 }
 

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -93,19 +93,19 @@ function getPrettierForFile(fileName: string): Prettier {
     // First try to use the local prettier for this file
     const local = requireLocalPkg<Prettier>(fileName, 'prettier');
     if (local) {
-        console.log('prettier: Formatting with local prettier');
+        addToOutput('Formatting with local prettier');
         return local;
     }
 
     // Fallback to global if no local is found
     const global = requireGlobalPrettier();
     if (global) {
-        console.log('prettier: Formatting with global prettier');
+        addToOutput('Formatting with global prettier');
         return global;
     }
 
     // Finally use the bundled one if all else fail
-    console.log('prettier: Formatting with bundled prettier');
+    addToOutput('Formatting with bundled prettier');
     return bundledPrettier;
 }
 

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -69,14 +69,14 @@ function updateStatusBar(message: string): void {
  *
  * @param module the module used
  * @param version the version of the module
- * @param bundled is it bundled with the extension or not
+ * @param type is it local, global or bundled
  */
 export function setUsedModule(
     module: string,
     version: string,
-    bundled: boolean
+    type: 'local' | 'global' | 'bundled'
 ) {
-    prettierInformation = `${module}@${version}${bundled ? ' (bundled)' : ''}`;
+    prettierInformation = `${module}@${version} (${type})`;
 }
 
 /**

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -1,7 +1,6 @@
 import {
     Disposable,
     StatusBarItem,
-    OutputChannel,
     StatusBarAlignment,
     TextEditor,
     commands,
@@ -13,7 +12,7 @@ import { allEnabledLanguages, getConfig } from './utils';
 import { PrettierVSCodeConfig } from './types';
 
 let statusBarItem: StatusBarItem;
-let outputChannel: OutputChannel;
+const outputChannel = window.createOutputChannel('Prettier');
 let prettierInformation: string;
 
 function toggleStatusBarItem(editor: TextEditor | undefined): void {
@@ -168,8 +167,6 @@ export function setupErrorHandler(): Disposable {
     toggleStatusBarItem(window.activeTextEditor);
 
     // Setup the outputChannel
-    outputChannel = window.createOutputChannel('Prettier');
-
     return commands.registerCommand('prettier.open-output', () => {
         outputChannel.show();
     });

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -145,7 +145,7 @@ export function safeExecution(
 
         return returnValue;
     } catch (err) {
-        addToOutput(addFilePath(err.message, fileName));
+        addToOutput(addFilePath(err.message || String(err), fileName));
         updateStatusBar('Prettier: $(x)');
 
         return defaultText;

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -36,18 +36,17 @@ function findPkg(fspath: string, pkgName: string): string | undefined {
  * @param {string} pkgName package's name to require
  * @returns module
  */
-function requireLocalPkg(fspath: string, pkgName: string): any {
+function requireLocalPkg<T>(fspath: string, pkgName: string): T | undefined {
     const modulePath = findPkg(fspath, pkgName);
+    console.log('Found module path', modulePath);
     if (modulePath !== void 0) {
         try {
             return require(modulePath);
         } catch (e) {
             addToOutput(
-                `Failed to load ${pkgName} from ${modulePath}. Using bundled`
+                `Failed to load ${pkgName} from ${modulePath}. Using bundled or global`
             );
         }
     }
-
-    return require(pkgName);
 }
 export { requireLocalPkg };

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -38,7 +38,6 @@ function findPkg(fspath: string, pkgName: string): string | undefined {
  */
 function requireLocalPkg<T>(fspath: string, pkgName: string): T | undefined {
     const modulePath = findPkg(fspath, pkgName);
-    console.log('Found module path', modulePath);
     if (modulePath !== void 0) {
         try {
             return require(modulePath);

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -38,9 +38,11 @@ function findPkg(fspath: string, pkgName: string): string | undefined {
  */
 function requireLocalPkg<T>(fspath: string, pkgName: string): T | undefined {
     let modulePath;
+    addToOutput('Looking local prettier for ' + fspath);
     try {
         modulePath = findPkg(fspath, pkgName);
         if (modulePath !== void 0) {
+            addToOutput('Found local prettier ' + modulePath);
             return require(modulePath);
         }
     } catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { workspace, Uri } from 'vscode';
-import { basename, dirname, join } from 'path';
+import { basename } from 'path';
 import {
     PrettierVSCodeConfig,
     Prettier,
@@ -12,21 +12,22 @@ import { execSync } from 'child_process';
 const requireGlobal = require('requireg');
 const bundledPrettier = require('prettier') as Prettier;
 
-let globalNodeExecPath: string | undefined;
+/**
+ * Path to the global node_modules directory
+ */
+let rootNodeModules: string | undefined;
 
 try {
-    globalNodeExecPath = execSync(
-        'node --eval "process.stdout.write(process.execPath)"'
-    ).toString();
+    rootNodeModules = execSync('npm root --quiet -g').toString();
 } catch (error) {
-    // Not installed
+    // No nodejs installed
 }
 
 /**
  * Require global prettier or undefined if none is installed
  */
 export function requireGlobalPrettier(): Prettier | undefined {
-    if (!globalNodeExecPath) {
+    if (!rootNodeModules) {
         return;
     }
 
@@ -34,7 +35,7 @@ export function requireGlobalPrettier(): Prettier | undefined {
     // So workaround it by setting NODE_PATH using the process.execPath from the
     // global node installation
     const origNodePath = process.env.NODE_PATH;
-    process.env.NODE_PATH = join(dirname(globalNodeExecPath), 'node_modules');
+    process.env.NODE_PATH = rootNodeModules;
 
     try {
         return requireGlobal('prettier', true);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { workspace, Uri } from 'vscode';
+import { workspace, Uri, window } from 'vscode';
 import { basename } from 'path';
 import {
     PrettierVSCodeConfig,
@@ -120,6 +120,11 @@ function getUniqueSupportedLanguages(prettierInstances: Prettier[]): string[] {
     for (const prettier of prettierInstances) {
         for (const language of getSupportLanguages(prettier)) {
             if (!language.vscodeLanguageIds) {
+                window.showErrorMessage(
+                    `Prettier plugin for ${
+                        language.name
+                    } does no support vscodeLanguageIds property`
+                );
                 continue;
             }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,10 +91,10 @@ export function allEnabledLanguages(): string[] {
 
     const globalPrettier = requireGlobalPrettier();
     if (globalPrettier) {
-        console.log('Has global Prettier');
+        console.log('prettier: Has global Prettier');
         prettierInstances = prettierInstances.concat(globalPrettier);
     } else {
-        console.log('No global Prettier');
+        console.log('prettier: No global Prettier');
     }
 
     if (workspace.workspaceFolders) {
@@ -111,7 +111,9 @@ export function allEnabledLanguages(): string[] {
         prettierInstances = prettierInstances.concat(localPrettiers);
     }
 
-    return getUniqueSupportedLanguages(prettierInstances);
+    const languages = getUniqueSupportedLanguages(prettierInstances);
+    console.log('prettier: supported languages: ' + languages.join(','));
+    return languages;
 }
 
 function getUniqueSupportedLanguages(prettierInstances: Prettier[]): string[] {
@@ -134,7 +136,6 @@ function getUniqueSupportedLanguages(prettierInstances: Prettier[]): string[] {
         }
     }
 
-    console.log('LANGS', prettierInstances.length, Array.from(languages));
     return Array.from(languages);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,14 +87,15 @@ export function notEmpty<TValue>(
  * bundled.
  */
 export function allEnabledLanguages(): string[] {
-    let prettierInstances: Prettier[] = [bundledPrettier];
+    let prettierInstances: Prettier[] = [];
 
     const globalPrettier = requireGlobalPrettier();
     if (globalPrettier) {
-        console.log('prettier: Has global Prettier');
+        console.log('prettier: Found global Prettier');
         prettierInstances = prettierInstances.concat(globalPrettier);
     } else {
-        console.log('prettier: No global Prettier');
+        prettierInstances = prettierInstances.concat(bundledPrettier);
+        console.log('prettier: No global Prettier. Using bundled.');
     }
 
     if (workspace.workspaceFolders) {


### PR DESCRIPTION
Closes #395
Closes #612 

It works by checking language support from each workspace that has a local Prettier installation and registers all supported languages as language formatters.

There's one caveat though. If you have multiple workspaces that have different prettier plugins installed you will get error message that a plugin is not installed if you try to format file in a workspace that does not have it installed but some other workspace has. I don't think there's a way around this because vscode registers formatters globally.

Prelease build from this PR: https://github.com/epeli/prettier-vscode/releases/download/1.8.103-prerelease/prettier-vscode-1.8.103-prerelease.vsix

Install with

```
code --install-extension prettier-vscode-1.8.103-prerelease.vsix
```