### PR TITLE
Support prettier 1.17

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+- [ ] Run tests
+- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes
+
+[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,6 +13,7 @@ testWorkspace.code-workspace
 scripts/**
 **/*.map
 .gitignore
+.github/**
 tsconfig.json
 vsc-extension-quickstart.md
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 -   Prettier [1.17](https://prettier.io/blog/2019/04/12/1.17.0.html)
+-   New setting `quoteProps`. (prettier 1.17)
 
 ## [1.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
 ## [Unreleased]
+-   Prettier [1.17](https://prettier.io/blog/2019/04/12/1.17.0.html)
 
 ## [1.8.0]
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Specify the global whitespace sensitivity for HTML files. [Learn more here](http
 #### prettier.endOfLine (default: 'auto')
 Specify the end of line used by prettier. [Learn more here](https://prettier.io/docs/en/options.html#end-of-line)
 
+#### prettier.quoteProps (default: 'as-needed')
+Change when properties in objects are quoted. [Learn more here](https://prettier.io/docs/en/options.html#quote-props)
 
 ### VSCode specific settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3981,9 +3981,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw=="
     },
     "prettier-eslint": {
       "version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
   },
   "dependencies": {
     "ignore": "^3.3.8",
-    "prettier": "1.16.3",
+    "prettier": "1.17.0",
     "prettier-eslint": "^8.8.2",
     "prettier-stylelint": "^0.4.2",
     "prettier-tslint": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,16 @@
           ],
           "default": "auto",
           "description": "Specify the end of line used by prettier"
+        },
+        "prettier.quoteProps": {
+          "type": "string",
+          "enum": [
+            "as-needed",
+            "consistent",
+            "preserve"
+          ],
+          "default": "as-needed",
+          "description": "Change when properties in objects are quoted"
         }
       }
     },

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -168,6 +168,7 @@ async function format(
             jsxSingleQuote: vscodeConfig.jsxSingleQuote,
             htmlWhitespaceSensitivity: vscodeConfig.htmlWhitespaceSensitivity,
             endOfLine: vscodeConfig.endOfLine,
+            quoteProps: vscodeConfig.quoteProps,
         }
     );
 

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -9,7 +9,8 @@ import {
     languages,
 } from 'vscode';
 
-import { allEnabledLanguages } from './utils';
+import { allEnabledLanguages, getConfig } from './utils';
+import { PrettierVSCodeConfig } from './types';
 
 let statusBarItem: StatusBarItem;
 let outputChannel: OutputChannel;
@@ -19,7 +20,7 @@ function toggleStatusBarItem(editor: TextEditor | undefined): void {
     if (statusBarItem === undefined) {
         return;
     }
-  
+
     if (editor !== undefined) {
         // The function will be triggered everytime the active "editor" instance changes
         // It also triggers when we focus on the output panel or on the debug panel
@@ -34,8 +35,9 @@ function toggleStatusBarItem(editor: TextEditor | undefined): void {
         }
 
         const score = languages.match(allEnabledLanguages(), editor.document);
+        const disabledLanguages: PrettierVSCodeConfig["disableLanguages"] = getConfig(editor.document.uri).disableLanguages;
 
-        if (score > 0) {
+        if (score > 0 && !disabledLanguages.includes(editor.document.languageId)) {
             statusBarItem.show();
         } else {
             statusBarItem.hide();

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -30,22 +30,23 @@ function findPkg(fspath: string, pkgName: string): string | undefined {
 }
 
 /**
- * Require package explicitely installed relative to given path.
+ * Require package explicitly installed relative to given path.
  * Fallback to bundled one if no pacakge was found bottom up.
  * @param {string} fspath file system path starting point to resolve package
  * @param {string} pkgName package's name to require
  * @returns module
  */
 function requireLocalPkg(fspath: string, pkgName: string): any {
-    const modulePath = findPkg(fspath, pkgName);
-    if (modulePath !== void 0) {
-        try {
+    let modulePath;
+    try {
+        modulePath = findPkg(fspath, pkgName);
+        if (modulePath !== void 0) {
             return require(modulePath);
-        } catch (e) {
-            addToOutput(
-                `Failed to load ${pkgName} from ${modulePath}. Using bundled`
-            );
         }
+    } catch (e) {
+        addToOutput(
+            `Failed to load ${pkgName} from ${modulePath}. Using bundled.`
+        );
     }
 
     return require(pkgName);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -55,6 +55,7 @@ export interface PrettierConfig {
     jsxSingleQuote: boolean;
     htmlWhitespaceSensitivity: 'css' | 'strict' | 'ignore';
     endOfLine: 'auto' | 'lf' | 'crlf' | 'cr';
+    quoteProps: 'as-needed' | 'consistent' | 'preserve';
 }
 /**
  * prettier-vscode specific configuration

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,5 +57,10 @@ export function getGroup(group: string): PrettierSupportInfo['languages'] {
 }
 
 function getSupportLanguages(prettierInstance: Prettier = bundledPrettier) {
-    return prettierInstance.getSupportInfo(prettierInstance.version).languages;
+    // prettier.getSupportInfo was added in prettier@1.8.0
+    if (prettierInstance.getSupportInfo) {
+        return prettierInstance.getSupportInfo(prettierInstance.version).languages;
+    } else {
+        return bundledPrettier.getSupportInfo(prettierInstance.version).languages;
+    }
 }

--- a/testWorkspace.code-workspace
+++ b/testWorkspace.code-workspace
@@ -27,6 +27,15 @@
         "prettier.disableLanguages": [],
         "prettier.endOfLine": "auto",
         "prettier.htmlWhitespaceSensitivity": "css",
-        "prettier.jsxSingleQuote": false
+        "prettier.jsxSingleQuote": false,
+        "[typescript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[json]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[javascript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        }
     }
 }

--- a/testWorkspace.code-workspace
+++ b/testWorkspace.code-workspace
@@ -28,6 +28,7 @@
         "prettier.endOfLine": "auto",
         "prettier.htmlWhitespaceSensitivity": "css",
         "prettier.jsxSingleQuote": false,
+        "prettier.quoteProps": "as-needed",
         "[typescript]": {
             "editor.defaultFormatter": "esbenp.prettier-vscode"
         },


### PR DESCRIPTION
Typescript 3.4 added support for the readonly modifer, which prettier 1.17 was released to support.  Without this prettier crashes on files using the readonly modifer.