### PR TITLE
Add support for local instance plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 -   New setting `quoteProps`. (prettier 1.17)
 
 -   Docs now explain how to lint TypeScript code with ESLint.
+-   Improve supported language resolution with local Prettier instances and plugins
 
 ## [1.8.0]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,10 +163,28 @@
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
     },
     "array-slice": {
       "version": "0.2.3",
@@ -1129,6 +1147,31 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -2517,6 +2560,12 @@
         "builtin-modules": "^1.0.0"
       }
     },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -2532,6 +2581,12 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-decimal": {
       "version": "1.0.2",
@@ -2690,6 +2745,15 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -2723,6 +2787,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
       "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ=="
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2839,6 +2912,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -3099,6 +3178,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "meow": {
       "version": "3.7.0",
@@ -3425,6 +3510,95 @@
         "once": "^1.3.2"
       }
     },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3724,6 +3898,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
       "dev": true
     },
     "pify": {
@@ -4699,6 +4879,18 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -5003,6 +5195,17 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,11 @@
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc --watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cd testEslint && npm i && cd ../testTslint && npm i && cd .. && cross-env CODE_TESTS_WORKSPACE=testWorkspace.code-workspace node ./node_modules/vscode/bin/test",
+    "test": "run-s test:prepare:* test:run",
+    "test:prepare:eslint": "npm install --prefix testEslint",
+    "test:prepare:tslint": "npm install --prefix testTslint",
+    "test:prepare:plugins": "npm install --prefix testPlugins",
+    "test:run": "cross-env CODE_TESTS_WORKSPACE=testWorkspace.code-workspace node ./node_modules/vscode/bin/test",
     "version": "node ./scripts/version.js && git add CHANGELOG.md"
   },
   "devDependencies": {
@@ -241,6 +245,7 @@
     "@types/resolve": "0.0.8",
     "cross-env": "^5.1.6",
     "mocha": "^5.2.0",
+    "npm-run-all": "^4.1.5",
     "vscode": "^1.1.28"
   },
   "dependencies": {

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -105,7 +105,6 @@ async function format(
 
     const dynamicParsers = getParsersFromLanguageId(
         languageId,
-        localPrettier,
         isUntitled ? undefined : fileName
     );
     let useBundled = false;
@@ -114,8 +113,8 @@ async function format(
     if (!dynamicParsers.length) {
         const bundledParsers = getParsersFromLanguageId(
             languageId,
-            bundledPrettier,
-            isUntitled ? undefined : fileName
+            isUntitled ? undefined : fileName,
+            true
         );
         parser = bundledParsers[0] || 'babylon';
         useBundled = true;

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -10,7 +10,8 @@ import {
 } from 'vscode';
 
 import { allEnabledLanguages, getConfig } from './utils';
-import { PrettierVSCodeConfig } from './types';
+import { PrettierVSCodeConfig, Prettier } from './types';
+import { requireLocalPkg } from './requirePkg';
 
 let statusBarItem: StatusBarItem;
 let outputChannel: OutputChannel;
@@ -34,7 +35,8 @@ function toggleStatusBarItem(editor: TextEditor | undefined): void {
             return;
         }
 
-        const score = languages.match(allEnabledLanguages(), editor.document);
+        const prettierInstance = requireLocalPkg(editor.document.uri.fsPath, 'prettier') as Prettier;
+        const score = languages.match(allEnabledLanguages(prettierInstance), editor.document);
         const disabledLanguages: PrettierVSCodeConfig["disableLanguages"] = getConfig(editor.document.uri).disableLanguages;
 
         if (score > 0 && !disabledLanguages.includes(editor.document.languageId)) {

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -10,8 +10,7 @@ import {
 } from 'vscode';
 
 import { allEnabledLanguages, getConfig } from './utils';
-import { PrettierVSCodeConfig, Prettier } from './types';
-import { requireLocalPkg } from './requirePkg';
+import { PrettierVSCodeConfig } from './types';
 
 let statusBarItem: StatusBarItem;
 let outputChannel: OutputChannel;
@@ -35,8 +34,8 @@ function toggleStatusBarItem(editor: TextEditor | undefined): void {
             return;
         }
 
-        const prettierInstance = requireLocalPkg(editor.document.uri.fsPath, 'prettier') as Prettier;
-        const score = languages.match(allEnabledLanguages(prettierInstance), editor.document);
+        const filePath = editor.document.isUntitled ? undefined : editor.document.fileName;
+        const score = languages.match(allEnabledLanguages(filePath), editor.document);
         const disabledLanguages: PrettierVSCodeConfig["disableLanguages"] = getConfig(editor.document.uri).disableLanguages;
 
         if (score > 0 && !disabledLanguages.includes(editor.document.languageId)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,14 +40,17 @@ function disposeHandlers() {
  * Build formatter selectors
  */
 function selectors(): Selectors {
-    let filePath;
-    if (workspace.workspaceFolders && workspace.workspaceFolders[0]) {
-        filePath = workspace.workspaceFolders[0].uri.fsPath;
+    let allLanguages: string[];
+    if (workspace.workspaceFolders === undefined) {
+        // filePath = workspace.workspaceFolders[0].uri.fsPath;
+        allLanguages = allEnabledLanguages();
     } else {
-        filePath = undefined;
+        allLanguages = [];
+        for (const folder of workspace.workspaceFolders) {
+            allLanguages.push(...allEnabledLanguages(folder.uri.fsPath));
+        }
     }
 
-    const allLanguages = allEnabledLanguages(filePath);
     const allRangeLanguages = rangeSupportedLanguages();
     const { disableLanguages } = getConfig();
     const globalLanguageSelector = allLanguages.filter(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,10 +15,6 @@ import {
 } from './utils';
 import configFileListener from './configCacheHandler';
 import ignoreFileHandler from './ignoreFileHandler';
-import { requireLocalPkg } from './requirePkg';
-import { Prettier } from './types.d';
-
-const bundledPrettier = require('prettier') as Prettier;
 
 interface Selectors {
     rangeLanguageSelector: DocumentSelector;
@@ -44,16 +40,14 @@ function disposeHandlers() {
  * Build formatter selectors
  */
 function selectors(): Selectors {
-    let prettierInstance: Prettier;
-
-    const workspaceFolders = workspace.workspaceFolders;
-    if (workspaceFolders && workspaceFolders[0]) {
-        prettierInstance = requireLocalPkg(workspaceFolders[0].uri.fsPath, 'prettier') as Prettier;
+    let filePath;
+    if (workspace.workspaceFolders && workspace.workspaceFolders[0]) {
+        filePath = workspace.workspaceFolders[0].uri.fsPath;
     } else {
-        prettierInstance = bundledPrettier;
+        filePath = undefined;
     }
 
-    const allLanguages = allEnabledLanguages(prettierInstance);
+    const allLanguages = allEnabledLanguages(filePath);
     const allRangeLanguages = rangeSupportedLanguages();
     const { disableLanguages } = getConfig();
     const globalLanguageSelector = allLanguages.filter(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,6 @@ function disposeHandlers() {
 function selectors(): Selectors {
     let allLanguages: string[];
     if (workspace.workspaceFolders === undefined) {
-        // filePath = workspace.workspaceFolders[0].uri.fsPath;
         allLanguages = allEnabledLanguages();
     } else {
         allLanguages = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,10 @@ import {
 } from './utils';
 import configFileListener from './configCacheHandler';
 import ignoreFileHandler from './ignoreFileHandler';
+import { requireLocalPkg } from './requirePkg';
+import { Prettier } from './types.d';
+
+const bundledPrettier = require('prettier') as Prettier;
 
 interface Selectors {
     rangeLanguageSelector: DocumentSelector;
@@ -40,7 +44,16 @@ function disposeHandlers() {
  * Build formatter selectors
  */
 function selectors(): Selectors {
-    const allLanguages = allEnabledLanguages();
+    let prettierInstance: Prettier;
+
+    const workspaceFolders = workspace.workspaceFolders;
+    if (workspaceFolders && workspaceFolders[0]) {
+        prettierInstance = requireLocalPkg(workspaceFolders[0].uri.fsPath, 'prettier') as Prettier;
+    } else {
+        prettierInstance = bundledPrettier;
+    }
+
+    const allLanguages = allEnabledLanguages(prettierInstance);
     const allRangeLanguages = rangeSupportedLanguages();
     const { disableLanguages } = getConfig();
     const globalLanguageSelector = allLanguages.filter(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,8 +34,8 @@ export function getParsersFromLanguageId(
     return language.parsers;
 }
 
-export function allEnabledLanguages(): string[] {
-    return getSupportLanguages().reduce(
+export function allEnabledLanguages(prettierInstance: Prettier): string[] {
+    return getSupportLanguages(prettierInstance).reduce(
         (ids, language) => [...ids, ...(language.vscodeLanguageIds || [])],
         [] as string[]
     );
@@ -52,11 +52,11 @@ export function rangeSupportedLanguages(): string[] {
     ];
 }
 
-export function getGroup(group: string): PrettierSupportInfo['languages'] {
-    return getSupportLanguages().filter(language => language.group === group);
+export function getGroup(group: string, prettierInstance: Prettier): PrettierSupportInfo['languages'] {
+    return getSupportLanguages(prettierInstance).filter(language => language.group === group);
 }
 
-function getSupportLanguages(prettierInstance: Prettier = bundledPrettier) {
+function getSupportLanguages(prettierInstance: Prettier) {
     // prettier.getSupportInfo was added in prettier@1.8.0
     if (prettierInstance.getSupportInfo) {
         return prettierInstance.getSupportInfo(prettierInstance.version).languages;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
 } from './types.d';
 
 const bundledPrettier = require('prettier') as Prettier;
+import { requireLocalPkg } from './requirePkg';
 
 export function getConfig(uri?: Uri): PrettierVSCodeConfig {
     return workspace.getConfiguration('prettier', uri) as any;
@@ -15,10 +16,10 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
 
 export function getParsersFromLanguageId(
     languageId: string,
-    prettierInstance: Prettier,
-    path?: string
+    path?: string,
+    useBundled: boolean = false
 ): ParserOption[] {
-    const language = getSupportLanguages(prettierInstance).find(
+    const language = getSupportLanguages(useBundled ? undefined : path).find(
         lang =>
             Array.isArray(lang.vscodeLanguageIds) &&
             lang.vscodeLanguageIds.includes(languageId) &&
@@ -34,8 +35,8 @@ export function getParsersFromLanguageId(
     return language.parsers;
 }
 
-export function allEnabledLanguages(prettierInstance: Prettier): string[] {
-    return getSupportLanguages(prettierInstance).reduce(
+export function allEnabledLanguages(path?: string): string[] {
+    return getSupportLanguages(path).reduce(
         (ids, language) => [...ids, ...(language.vscodeLanguageIds || [])],
         [] as string[]
     );
@@ -52,11 +53,18 @@ export function rangeSupportedLanguages(): string[] {
     ];
 }
 
-export function getGroup(group: string, prettierInstance: Prettier): PrettierSupportInfo['languages'] {
-    return getSupportLanguages(prettierInstance).filter(language => language.group === group);
+export function getGroup(group: string, path?: string): PrettierSupportInfo['languages'] {
+    return getSupportLanguages(path).filter(language => language.group === group);
 }
 
-function getSupportLanguages(prettierInstance: Prettier) {
+function getSupportLanguages(path?: string) {
+    let prettierInstance: Prettier;
+    if (path) {
+        prettierInstance = requireLocalPkg(path, 'prettier');
+    } else {
+        prettierInstance = bundledPrettier;
+    }
+
     // prettier.getSupportInfo was added in prettier@1.8.0
     if (prettierInstance.getSupportInfo) {
         return prettierInstance.getSupportInfo(prettierInstance.version).languages;

--- a/test/plugins.test.ts
+++ b/test/plugins.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import { format } from './format.test';
+import { workspace } from 'vscode';
+
+suite('Test plugins', function() {
+    test('it formats with plugins', () => {
+        return format('index.php', workspace.workspaceFolders![4].uri).then(
+            ({ result, source }) => {
+                assert.equal(
+                    result,
+                    `<?php
+
+array_map(
+  function ($arg1, $arg2) use ($var1, $var2) {
+    return $arg1 + $arg2 / ($var + $var2);
+  },
+  array(
+    "complex" => "code",
+    "with" => "inconsistent",
+    "formatting" => "is",
+    "hard" => "to",
+    "maintain" => true
+  )
+);
+`
+                );
+            }
+        );
+    });
+});

--- a/testPlugins/index.php
+++ b/testPlugins/index.php
@@ -1,0 +1,5 @@
+<?php
+
+array_map(function($arg1,$arg2) use ( $var1, $var2 ) {
+  return $arg1+$arg2/($var+$var2);
+}, array("complex"=>"code","with"=>"inconsistent","formatting"=>"is", "hard" => "to", "maintain"=>true));

--- a/testPlugins/package-lock.json
+++ b/testPlugins/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "testplugins",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@prettier/plugin-php": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.10.2.tgz",
+      "integrity": "sha512-FCzNR2kqlS9YV81JguX4vYnpwFn6cOlLwUZaEB0jIjPcrEgqqBwk6KSERTA5cE+lX5Ynip5rkV1hydGufwyJ7A==",
+      "dev": true,
+      "requires": {
+        "linguist-languages": "^6.3.0",
+        "mem": "^4.0.0",
+        "php-parser": "github:glayzzle/php-parser#71485979b688d12fb130d3e853fdc00348671e00"
+      }
+    },
+    "linguist-languages": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-6.3.0.tgz",
+      "integrity": "sha512-d86fIQM00SqmBmAErxRpBEBe2Nw/WK4Se999wavaXc+lqarOLnoenGP3V/wgBclxKsRXEYWTd6mvv8373vPSKg==",
+      "dev": true
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "php-parser": {
+      "version": "github:glayzzle/php-parser#71485979b688d12fb130d3e853fdc00348671e00",
+      "from": "github:glayzzle/php-parser#71485979b688d12fb130d3e853fdc00348671e00",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "dev": true
+    }
+  }
+}

--- a/testPlugins/package.json
+++ b/testPlugins/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "testplugins",
+  "version": "1.0.0",
+  "description": "Test folder for prettier plugins",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "jarrodldavis",
+  "license": "MIT",
+  "devDependencies": {
+    "@prettier/plugin-php": "^0.10.2",
+    "prettier": "^1.17.0"
+  },
+  "dependencies": {}
+}

--- a/testWorkspace.code-workspace
+++ b/testWorkspace.code-workspace
@@ -11,6 +11,9 @@
         },
         {
             "path": "testTslint"
+        },
+        {
+            "path": "testPlugins"
         }
     ],
     "settings": {
@@ -36,6 +39,9 @@
             "editor.defaultFormatter": "esbenp.prettier-vscode"
         },
         "[javascript]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[php]": {
             "editor.defaultFormatter": "esbenp.prettier-vscode"
         }
     }


### PR DESCRIPTION
This improves upon the changes in #706 to always resolve the local prettier instance when resolving supported languages.

This allows format provider and status bar handler to be aware of locally-installed Prettier plugins.

This is an alternative implementation of #757, and should fix #395 and fix #612 as well.


- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md