### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Prettier formatter for Visual Studio Code
 
-VS Code package to format your JavaScript / TypeScript / CSS using [Prettier](https://github.com/prettier/prettier).
+VS Code package to format your:
+- HTML / Vue / Angular
+- JavaScript / JSX / Flow / TypeScript / JSON
+- CSS / LESS / SCSS Styled Components / Styled JSX
+- Markdown / CommonMark / GitHub-Flavored Markdown / MDX
+- YAML
+
+using [Prettier](https://github.com/prettier/prettier).
 
 ## Installation
 


### PR DESCRIPTION
It's annoying to not know this plugin formats all these types of files. It took me quite a while to discover it was Prettier doing the (wrongly configured) formatting. This way people know exactly what files Prettier will try to format.

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
