### PR TITLE
Create config option for passing prettier-eslint options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 -   New setting `quoteProps`. (prettier 1.17)
 
 -   Docs now explain how to lint TypeScript code with ESLint.
+-   New option: eslintIntegrationOptions (object) provide config options to `prettier-eslint`
 
 ## [1.8.0]
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Other settings will only be fallbacks in case they could not be inferred from TS
 Use *[prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint)* instead of *prettier*.
 Other settings will only be fallbacks in case they could not be inferred from stylelint rules.
 
+#### prettier.eslintIntegrationOptions (default: {}) - JavaScript and TypeScript only
+Provide configuration options to *[prettier-eslint](https://github.com/prettier/prettier-eslint#options)*. Requires `"prettier.eslintIntegration" `to be be `true`.
+
 #### prettier.requireConfig (default: false)
 Require a 'prettierconfig' to format
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,12 @@
           "description": "Use 'prettier-eslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from eslint rules.",
           "scope": "resource"
         },
+        "prettier.eslintIntegrationOptions": {
+          "type": "object",
+          "default": {},
+          "description": "Provide configuration options to 'prettier-eslint'. Requires 'prettier.eslintIntegration' to be be true.",
+          "scope": "resource"
+        },
         "prettier.tslintIntegration": {
           "type": "boolean",
           "default": false,

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -200,6 +200,7 @@ async function format(
                     text,
                     filePath: fileName,
                     fallbackPrettierOptions: prettierOptions,
+                    ...vscodeConfig.eslintIntegrationOptions,
                 });
             },
             text,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -77,6 +77,11 @@ interface ExtensionConfig {
      */
     stylelintIntegration: boolean;
     /**
+     * Provide configuration options to 'prettier-eslint'.
+     * Requires `"prettier.eslintIntegration"` to be be `true`.
+     */
+    eslintIntegrationOptions: PrettierEslintOptions;
+    /**
      * Path to '.prettierignore' or similar.
      */
     ignorePath: string;


### PR DESCRIPTION
Add a config option to allow modification of `prettier-eslint` options as mentioned in #877.

Normally I would wait for comments on the issue, but this issue was causing some delays in my work and I needed a fix. Let me know if there is any improvement I can make to this implementation.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
