### PR TITLE
Fix running tests from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
       "args": [
         "--disable-extensions",
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite"
       ],
       "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
       "preLaunchTask": "npm: compile"


### PR DESCRIPTION
- [x] Run tests (using `yarn test`; from GUI fails)
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md

I can update the changelog if you want but I anticipate another PR or updates to finish this.

When I run Extension Tests, it fails with 0 tests passing. This is because https://github.com/prettier/prettier-vscode/blob/623a04085226442c7a0b5b84894e5eadf87a5f49/src/test/suite/index.ts#L23 is trying to glob from a nonexistent folder `index`.
![image](https://user-images.githubusercontent.com/5614134/64086177-8dce5000-cceb-11e9-8a01-797a1753a091.png)

After this, all the tests run but none pass.

So this doesn't completely fix the issue of running the tests from the launch.json task.

When running from the launch.json task, `vscode.workspace.workspaceFolders` is undefined, and even if it was defined, there is no "project" folder which is targeted at https://github.com/prettier/prettier-vscode/blob/623a04085226442c7a0b5b84894e5eadf87a5f49/src/test/suite/format.test.ts#L52

I tried to fix the `vscode.workspace.workspaceFolders` issue by creating a `prettier.code-workspace` folder and running from that instead, but somehow it's still undefined - any suggestions? I messed around with a branch at https://github.com/prettier/prettier-vscode/compare/master...jcrben:add-workspace?expand=1

Note that if I run a non-test debugging session and open a workspace in the Extension Development Host, then the workspaceFolders is defined to include whichever workspace I've opened in the Extension Development Host.

Looks like the testing setup follows https://code.visualstudio.com/api/working-with-extensions/testing-extension pretty closely; I opened https://github.com/microsoft/vscode-test/issues/41 to try to learn more about how to synchronize approaches.