### PR TITLE
add filepath to prettierOptions

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -178,6 +178,7 @@ async function format(
       useTabs: vscodeConfig.useTabs
     }
   );
+  prettierOptions.filepath = fileName;
 
   if (vscodeConfig.tslintIntegration && parser === 'typescript') {
     return safeExecution(


### PR DESCRIPTION
Add `filepath` to `prettierOptions` in `PrettierEditProvider.ts`.
This resolves the issue of https://github.com/prettier/prettier-vscode/issues/955, since prettier judges whether a file is `*.tsx` based on `options.filepath` (see https://github.com/prettier/prettier/blob/bb037eb218cbcf914575fe95d9f43e87ffab69a9/src/language-js/printer-estree.js).

- [ ] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
