### PR TITLE
fix 'VS Code ESLint and TSLint Integration' links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [2.1.0]
 
-- Deprecated support for ESLint, TSLint, and Stylelint. [See documentation](https://github.com/prettier/prettier-vscode#vscode-eslint-and-tslint-integration)
+- Deprecated support for ESLint, TSLint, and Stylelint. [See documentation](https://github.com/prettier/prettier-vscode#vs-code-eslint-and-tslint-integration)
 
 ## [1.12.0]
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,5 +21,5 @@
   "ext.config.eslintIntegration": "Use 'prettier-eslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from eslint rules.",
   "ext.config.tslintIntegration": "Use 'prettier-tslint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from tslint rules.",
   "ext.config.stylelintIntegration": "Use 'prettier-stylelint' instead of 'prettier'. Other settings will only be fallbacks in case they could not be inferred from stylelint rules.",
-  "ext.config.lintDeprecationMessage": "This setting has been deprecated. See: https://github.com/prettier/prettier-vscode#vscode-eslint-and-tslint-integration"
+  "ext.config.lintDeprecationMessage": "This setting has been deprecated. See: https://github.com/prettier/prettier-vscode#vs-code-eslint-and-tslint-integration"
 }


### PR DESCRIPTION
noticed the tooltip link to the "VS Code ESLint and TSLint Integration" section of the `README` was wrong when I was editing my workspace settings; it's also wrong in `CHANGELOG`

- [ ] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
