### PR TITLE
Add mongo to supported languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [2.5.0]
+
+- Add support for formatting .mongo files
+
 ## [2.4.0]
 
 - Set filepath config on format to assist with parser resolution

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,8 @@ export function rangeSupportedLanguages(): string[] {
     "typescript",
     "typescriptreact",
     "json",
-    "graphql"
+    "graphql",
+    "mongo"
   ];
 }
 


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md

The Mongo Language has JS Syntax but is not formatted by Prettier. Changing language mode to "JS" for .mongo files works for formatting, but then the command to run the query against the DB is not available. It would make working with MongoDB inside of VS Code much easier !