### PR TITLE
Fix for running Prettier on files in node_modules dirs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
-## 3.6.0]
+- Fix for finding local `prettier` module in packages located in `node_modules` dirs.
+
+## [3.6.0]
 
 - Added back status bar button
 

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -172,8 +172,19 @@ export class ModuleResolver implements Disposable {
    * @returns {string} resolved path to module
    */
   private findPkg(fspath: string, pkgName: string): string | undefined {
-    const res = readPkgUp.sync({ cwd: fspath, normalize: false });
-    const { root } = path.parse(fspath);
+    // Get the closest `package.json` file, that's outside of any `node_modules`
+    // directory.
+    const splitPath = fspath.split("/");
+    let finalPath = fspath;
+    const nodeModulesIndex = splitPath.indexOf("node_modules");
+
+    if (nodeModulesIndex > -1) {
+      finalPath = splitPath.slice(0, nodeModulesIndex).join("/");
+    }
+
+    const res = readPkgUp.sync({ cwd: finalPath, normalize: false });
+    const { root } = path.parse(finalPath);
+
     if (
       res &&
       res.packageJson &&

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -178,7 +178,7 @@ export class ModuleResolver implements Disposable {
     let finalPath = fspath;
     const nodeModulesIndex = splitPath.indexOf("node_modules");
 
-    if (nodeModulesIndex > -1) {
+    if (nodeModulesIndex > 1) {
       finalPath = splitPath.slice(0, nodeModulesIndex).join("/");
     }
 


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md

This is a fix for when opening a file in a `node_modules` dir, that also has `prettier` as a dep.

This closes #1064.