### PR TITLE
Fix missing quotes at Linter Integration README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ You can enable Auto-Fix on Save for either TSLint or ESLint and still have forma
     "source.fixAll.tslint": true
 },
 // For Stylelint
-stylelint.autoFixOnSave: true,
+"stylelint.autoFixOnSave": true,
 ```
 
 > NOTE: If you are seeing conflicts between Prettier and ESLint this is because you don't have the right ESLint or TSLint rules set as explained in the [Prettier documentation](https://prettier.io/docs/en/integrating-with-linters.html).


### PR DESCRIPTION
Just fix small missing string quotes at the README.md file. 