### PR TITLE
Honor project-scoped config when loading module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [next]
+
+- Honor project-scoped config when loading module
+
 ## [4.0.0]
 
 - Updated prettier to 2.0 - [See changes here](https://prettier.io/blog/2020/03/21/2.0.0.html).

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -7,7 +7,7 @@ import * as readPkgUp from "read-pkg-up";
 import * as resolve from "resolve";
 import * as semver from "semver";
 // tslint:disable-next-line: no-implicit-dependencies
-import { Disposable } from "vscode";
+import { Disposable, Uri } from "vscode";
 import { resolveGlobalNodePath, resolveGlobalYarnPath } from "./Files";
 import { LoggingService } from "./LoggingService";
 import { FAILED_TO_LOAD_MODULE_MESSAGE } from "./message";
@@ -88,7 +88,9 @@ export class ModuleResolver implements Disposable {
       return prettier;
     }
 
-    const { prettierPath, packageManager, resolveGlobalModules } = getConfig();
+    const { prettierPath, packageManager, resolveGlobalModules } = getConfig(
+      Uri.file(fileName)
+    );
 
     // tslint:disable-next-line: prefer-const
     let { moduleInstance, modulePath } = this.requireLocalPkg<PrettierModule>(


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md

Resolves #1222 

This PR makes sure that when we load the module, we pull the project-local configuration and allow it to override the workspace's configuration. Before this, the `prettier.prettierPath` could only be set globally and in the workspace settings.