### PR TITLE
Add support for arm-template language, which is a superset of JSON

### DIFF
--- a/src/LanguageResolver.ts
+++ b/src/LanguageResolver.ts
@@ -56,7 +56,7 @@ export class LanguageResolver {
       "javascriptreact",
       "typescript",
       "typescriptreact",
-      "json",      
+      "json",
       "graphql",
     ];
   }

--- a/src/LanguageResolver.ts
+++ b/src/LanguageResolver.ts
@@ -51,7 +51,7 @@ export class LanguageResolver {
 
   public rangeSupportedLanguages(): string[] {
     return [
-      "arm-template",
+      "arm-template", // JSON
       "javascript",
       "javascriptreact",
       "typescript",

--- a/src/LanguageResolver.ts
+++ b/src/LanguageResolver.ts
@@ -51,11 +51,12 @@ export class LanguageResolver {
 
   public rangeSupportedLanguages(): string[] {
     return [
+      "arm-template",
       "javascript",
       "javascriptreact",
       "typescript",
       "typescriptreact",
-      "json",
+      "json",      
       "graphql",
     ];
   }


### PR DESCRIPTION
Currently formatting an ARM template does not work any more since the ARM extension defined their own language: https://github.com/microsoft/vscode-azurearmtools/issues/465

I haven't tested this change, this is to start discussion if it would be as simple as that to re-add support for this language, which is just a superset of `jsonc`.

- [ ] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
