### PR TITLE
Add custom error message for invalid prettierPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 ## [next]
 
 - Update loading implicit Prettier dep from `node_modules` to only occur if explicit `package.json` dep is not found in a parent directory
+- Show a custom error message / notification in the case where `prettier.prettierPath` does not reference an instance of Prettier
 
 ## [4.5.0]
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,5 +1,7 @@
 export const OUTDATED_PRETTIER_VERSION_MESSAGE =
   "Your project is configured to use an outdated version of prettier that cannot be used by this extension. Upgrade to the latest version of prettier.";
+export const INVALID_PRETTIER_PATH_MESSAGE =
+  "`prettierPath` option does not reference a valid instance of Prettier. Please ensure you are passing a path to the prettier module, not the binary. Falling back to bundled version of prettier.";
 export const VIEW_LOGS_ACTION_TEXT = "Show Log";
 export const FAILED_TO_LOAD_MODULE_MESSAGE =
   "Failed to load module. If you have prettier or plugins referenced in package.json, ensure you have run `npm install`";

--- a/src/test/suite/notifications.test.ts
+++ b/src/test/suite/notifications.test.ts
@@ -2,8 +2,11 @@ import * as assert from "assert";
 // tslint:disable-next-line: no-implicit-dependencies
 import * as sinon from "sinon";
 // tslint:disable-next-line: no-implicit-dependencies
-import { MessageItem, MessageOptions, window } from "vscode";
-import { OUTDATED_PRETTIER_VERSION_MESSAGE } from "../../message";
+import { MessageItem, MessageOptions, window, workspace } from "vscode";
+import {
+  OUTDATED_PRETTIER_VERSION_MESSAGE,
+  INVALID_PRETTIER_PATH_MESSAGE,
+} from "../../message";
 import { format } from "./format.test";
 
 suite("Test notifications", function () {
@@ -28,6 +31,18 @@ suite("Test notifications", function () {
     await format("outdated", "ugly.js");
     assert(showErrorMessage.calledWith(OUTDATED_PRETTIER_VERSION_MESSAGE));
   });
+
+  test("shows error for invalid prettier instance", async () => {
+    const settings = workspace.getConfiguration("prettier");
+    const originalPrettierPath = settings.get("prettierPath");
+    await settings.update("prettierPath", "./node_modules/.bin/prettier");
+    await format("explicit-dep", "index.js");
+
+    assert(showErrorMessage.calledWith(INVALID_PRETTIER_PATH_MESSAGE));
+
+    await settings.update("prettierPath", originalPrettierPath);
+  });
+
   test("does not show error with valid project", async () => {
     await format("plugins", "index.php");
     assert(showWarningMessage.notCalled);

--- a/test-fixtures/test.code-workspace
+++ b/test-fixtures/test.code-workspace
@@ -90,6 +90,7 @@
     "[php]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "prettier.trailingComma": "all"
+    "prettier.trailingComma": "all",
+    "prettier.prettierPath": ""
   }
 }


### PR DESCRIPTION
Resolves https://github.com/prettier/prettier-vscode/issues/1258

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes


Tests are currently failing due to https://github.com/prettier/prettier-vscode/pull/1356, will rebase on master once it is merged.

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
