### PR TITLE
Remove hardcoded prettier defaults for compatibility with earlier versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [Unreleased]
+
+- By default, allow prettier to control defaults itself. Overrides configured in the plugin settings will only be passed if non-default.
+
 ## [5.0.0]
 
 - Removed support for legacy linter integration. [See documentation](https://github.com/prettier/prettier-vscode#linter-integration) on how to configure linters.

--- a/README.md
+++ b/README.md
@@ -208,9 +208,7 @@ Disable format on save so this extension doesn't run and enable code actions to 
 
 ### Prettier Settings
 
-All prettier options can be configured directly in this extension. These settings are used as a fallback when no configuration file is present in your project, see the [configuration](#configuration) section of this document for more details. For reference on the options see the [prettier documentation](https://prettier.io/docs/en/options.html).
-
-> The default values of these configurations are always to their Prettier 2.0 defaults. In order to use defaults from earlier versions of prettier you must set them manually using your VS Code settings or local project configurations.
+All prettier options can be configured directly in this extension. These settings are used as a fallback when no configuration file is present in your project, see the [configuration](#configuration) section of this document for more details. If left unchanged, the prettier default will be used. For reference on the options see the [prettier documentation](https://prettier.io/docs/en/options.html).
 
 ```
 prettier.arrowParens

--- a/package.json
+++ b/package.json
@@ -187,134 +187,218 @@
           "scope": "resource"
         },
         "prettier.printWidth": {
-          "type": "integer",
-          "default": 80,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "default": null,
           "markdownDescription": "%ext.config.printWidth%",
           "scope": "resource"
         },
         "prettier.tabWidth": {
-          "type": "integer",
-          "default": 2,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "default": null,
           "markdownDescription": "%ext.config.tabWidth%",
           "scope": "resource"
         },
         "prettier.singleQuote": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "enum": [
+            "default",
+            false,
+            true
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.singleQuote%",
           "scope": "resource"
         },
         "prettier.trailingComma": {
           "type": "string",
           "enum": [
+            "default",
             "none",
             "es5",
             "all"
           ],
-          "default": "es5",
+          "default": "default",
           "markdownDescription": "%ext.config.trailingComma%",
           "scope": "resource"
         },
         "prettier.bracketSpacing": {
-          "type": "boolean",
-          "default": true,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.bracketSpacing%",
           "scope": "resource"
         },
         "prettier.jsxBracketSameLine": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.jsxBracketSameLine%",
           "scope": "resource"
         },
         "prettier.semi": {
-          "type": "boolean",
-          "default": true,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.semi%",
           "scope": "resource"
         },
         "prettier.requirePragma": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.requirePragma%",
           "scope": "resource"
         },
         "prettier.insertPragma": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.insertPragma%",
           "scope": "resource"
         },
         "prettier.useTabs": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.useTabs%",
           "scope": "resource"
         },
         "prettier.proseWrap": {
           "type": "string",
           "enum": [
+            "default",
             "preserve",
             "always",
             "never"
           ],
-          "default": "preserve",
+          "default": "default",
           "markdownDescription": "%ext.config.proseWrap%",
           "scope": "resource"
         },
         "prettier.arrowParens": {
           "type": "string",
           "enum": [
+            "default",
             "avoid",
             "always"
           ],
-          "default": "always",
+          "default": "default",
           "markdownDescription": "%ext.config.arrowParens%",
           "scope": "resource"
         },
         "prettier.jsxSingleQuote": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.jsxSingleQuote%",
           "scope": "resource"
         },
         "prettier.htmlWhitespaceSensitivity": {
           "type": "string",
           "enum": [
+            "default",
             "css",
             "strict",
             "ignore"
           ],
-          "default": "css",
+          "default": "default",
           "markdownDescription": "%ext.config.htmlWhitespaceSensitivity%",
           "scope": "resource"
         },
         "prettier.vueIndentScriptAndStyle": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            "default",
+            true,
+            false
+          ],
+          "default": "default",
           "markdownDescription": "%ext.config.vueIndentScriptAndStyle%",
           "scope": "resource"
         },
         "prettier.endOfLine": {
           "type": "string",
           "enum": [
+            "default",
             "auto",
             "lf",
             "crlf",
             "cr"
           ],
-          "default": "lf",
+          "default": "default",
           "markdownDescription": "%ext.config.endOfLine%",
           "scope": "resource"
         },
         "prettier.quoteProps": {
           "type": "string",
           "enum": [
+            "default",
             "as-needed",
             "consistent",
             "preserve"
           ],
-          "default": "as-needed",
+          "default": "default",
           "markdownDescription": "%ext.config.quoteProps%",
           "scope": "resource"
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,5 +28,30 @@ export function getWorkspaceRelativePath(
 }
 
 export function getConfig(uri?: Uri): PrettierVSCodeConfig {
-  return workspace.getConfiguration("prettier", uri) as any;
+  const rawConfig = workspace.getConfiguration("prettier", uri) as any;
+  const config = { ...rawConfig };
+  [
+    "arrowParens",
+    "bracketSpacing",
+    "endOfLine",
+    "htmlWhitespaceSensitivity",
+    "insertPragma",
+    "jsxBracketSameLine",
+    "jsxSingleQuote",
+    "printWidth",
+    "proseWrap",
+    "quoteProps",
+    "requirePragma",
+    "semi",
+    "singleQuote",
+    "tabWidth",
+    "trailingComma",
+    "useTabs",
+    "vueIndentScriptAndStyle",
+  ].forEach((key) => {
+    if (config[key] === "default" || config[key] === null) {
+      delete config[key];
+    }
+  });
+  return config;
 }


### PR DESCRIPTION
Some of Prettier's defaults changed in version 2.0, so the defaults in this vscode plugin were updated to match in c2e9c55f. This caused configuration to break for prettier 1.x projects without explicit config files. This commit adds a new 'default' option to each of these settings. With this new default, the plugin does not pass any value for that setting to prettier, allowing the version-specific default to be used.

If overrides are selected in the config, they are passed along to prettier as before.

This resolves #1290 using a different approach to 5baeeb6, and I think it should be more future-proof against prettier changing defaults again in future.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/master/CHANGELOG.md
