### PR TITLE
Throttle fs watch registerFormatter calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",
+    "@types/lodash.throttle": "^4.1.6",
     "@types/mocha": "^8.0.0",
     "@types/node": "^12",
     "@types/prettier": "^2.0.2",
@@ -115,6 +116,7 @@
   "dependencies": {
     "find-up": "^5.0.0",
     "ignore": "^5.1.8",
+    "lodash.throttle": "^4.1.1",
     "mem": "^6.1.0",
     "prettier": "^2.1.0",
     "resolve": "^1.17.0",

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -1,3 +1,4 @@
+import throttle = require("lodash.throttle");
 import * as prettier from "prettier";
 import {
   Disposable,
@@ -59,9 +60,9 @@ export default class PrettierEditService implements Disposable {
 
   public registerDisposables(): Disposable[] {
     const packageWatcher = workspace.createFileSystemWatcher("**/package.json");
-    packageWatcher.onDidChange(this.registerFormatter);
-    packageWatcher.onDidCreate(this.registerFormatter);
-    packageWatcher.onDidDelete(this.registerFormatter);
+    packageWatcher.onDidChange(this.registerFormatterThrottled);
+    packageWatcher.onDidCreate(this.registerFormatterThrottled);
+    packageWatcher.onDidDelete(this.registerFormatterThrottled);
 
     const configurationWatcher = workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("prettier")) {
@@ -76,9 +77,9 @@ export default class PrettierEditService implements Disposable {
     const prettierConfigWatcher = workspace.createFileSystemWatcher(
       `**/{${PRETTIER_CONFIG_FILES.join(",")}}`
     );
-    prettierConfigWatcher.onDidChange(this.registerFormatter);
-    prettierConfigWatcher.onDidCreate(this.registerFormatter);
-    prettierConfigWatcher.onDidDelete(this.registerFormatter);
+    prettierConfigWatcher.onDidChange(this.registerFormatterThrottled);
+    prettierConfigWatcher.onDidCreate(this.registerFormatterThrottled);
+    prettierConfigWatcher.onDidDelete(this.registerFormatterThrottled);
 
     return [
       packageWatcher,
@@ -101,6 +102,8 @@ export default class PrettierEditService implements Disposable {
       editProvider
     );
   };
+
+  private registerFormatterThrottled = throttle(this.registerFormatter, 300);
 
   public dispose = () => {
     this.moduleResolver.dispose();

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/lodash.throttle@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz#f5ba2c22244ee42ff6c2c49e614401a870c1009c"
+  integrity sha512-/UIH96i/sIRYGC60NoY72jGkCJtFN5KVPhEMMMTjol65effe1gPn0tycJqV5tlSwMTzX8FqzB5yAj0rfGHTPNg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.160"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.160.tgz#2f1bba6500bc3cb9a732c6d66a083378fb0b0b29"
+  integrity sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2709,6 +2721,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash@^4.15.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"


### PR DESCRIPTION
In a large monorepo with fixed/locked mode versioning, many `package.json` files can change at once when the repo's version is bumped.

With ~500 packages updating their package.json at once, I observed `vscode-prettier` hanging VSCode's extension host process for several minutes. During this time, `vscode-prettier` repeatedly calls `registerFormatter`. Profiling showed Node.js's require function taking up most of `registerFormatter`'s time.

This commit adds a throttle to `registerFormatter` calls triggered through fs watch events.