### PR TITLE
setting correct working directory when prettier is installed locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [5.7.2]
+
+- setting correct working directory when prettier is installed locally
+
 ## [5.7.1]
 
 - Log the location of the prettier config file

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prettier-vscode",
   "displayName": "Prettier - Code formatter",
   "description": "Code formatter using prettier",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "publisher": "esbenp",
   "author": "Prettier <@prettiercode>",
   "galleryBanner": {

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -202,6 +202,11 @@ export class ModuleResolver implements Disposable {
 
       if (modulePath !== undefined) {
         const moduleInstance = this.loadNodeModule(moduleName, modulePath);
+        const workspacePath = getWorkspaceRelativePath(fsPath, "");
+        if (workspacePath) {
+          // Change current working directory
+          process.chdir(workspacePath);
+        }
         return { moduleInstance, modulePath };
       }
     } catch (error) {


### PR DESCRIPTION
This request is setting current working directory when prettier is running locally

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
