### PR TITLE
Automatically detect package manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [5.9.0]
+- Automatically detect package manager
+
 ## [5.8.0]
 
 - Updated prettier to 2.2.0

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Supply a custom path to the prettier module. This path should be to the module f
 
 #### prettier.packageManager
 
-Controls the package manager to be used to resolve modules. This has only an influence if the `prettier.resolveGlobalModules` setting is `true` and modules are resolved globally. Valid values are `"npm"` or `"yarn"` or `"pnpm"`.
+Controls the package manager to be used to resolve modules. This has only an influence if the `prettier.resolveGlobalModules` setting is `true` and modules are resolved globally. Valid values are `"auto"` or `"npm"` or `"yarn"` or `"pnpm"`.
 
 #### prettier.resolveGlobalModules (default: `false`)
 

--- a/README.md
+++ b/README.md
@@ -262,10 +262,6 @@ Supply a custom path to the prettier configuration file.
 
 Supply a custom path to the prettier module. This path should be to the module folder, not the bin/script path. i.e. `./node_modules/prettier`, not `./bin/prettier`.
 
-#### prettier.packageManager
-
-Controls the package manager to be used to resolve modules. This has only an influence if the `prettier.resolveGlobalModules` setting is `true` and modules are resolved globally. Valid values are `"auto"` or `"npm"` or `"yarn"` or `"pnpm"`.
-
 #### prettier.resolveGlobalModules (default: `false`)
 
 When enabled, this extension will attempt to use global npm or yarn modules if local modules cannot be resolved.

--- a/package.json
+++ b/package.json
@@ -172,11 +172,12 @@
           "scope": "resource",
           "type": "string",
           "enum": [
+            "auto",
             "npm",
             "yarn",
             "pnpm"
           ],
-          "default": "npm",
+          "default": "auto",
           "markdownDescription": "%ext.config.packageManager%"
         },
         "prettier.useEditorConfig": {

--- a/package.json
+++ b/package.json
@@ -168,18 +168,6 @@
           "markdownDescription": "%ext.config.withNodeModules%",
           "scope": "resource"
         },
-        "prettier.packageManager": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "auto",
-            "npm",
-            "yarn",
-            "pnpm"
-          ],
-          "default": "auto",
-          "markdownDescription": "%ext.config.packageManager%"
-        },
         "prettier.useEditorConfig": {
           "type": "boolean",
           "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,7 +11,6 @@
   "ext.config.insertPragma": "Prettier can insert a special @format marker at the top of files specifying that the file has been formatted with prettier. This works well when used in tandem with the `--require-pragma` option. If there is already a docblock at the top of the file then this option will add a newline to it with the @format marker.",
   "ext.config.jsxBracketSameLine": "If true, puts the `>` of a multi-line jsx element at the end of the last line instead of being alone on the next line",
   "ext.config.jsxSingleQuote": "Use single quotes instead of double quotes in JSX",
-  "ext.config.packageManager": "The package manager you use to install node modules.",
   "ext.config.parser": "Override the parser. You shouldn't have to change this setting.",
   "ext.config.parserDeprecationMessage": "This setting is no longer supported. Use a prettier configuration file instead.",
   "ext.config.prettierPath": "Path to the prettier module",

--- a/src/LanguageResolver.ts
+++ b/src/LanguageResolver.ts
@@ -4,10 +4,10 @@ import { ModuleResolver } from "./ModuleResolver";
 
 export class LanguageResolver {
   constructor(private moduleResolver: ModuleResolver) {}
-  public getParserFromLanguageId(
+  public async getParserFromLanguageId(
     uri: Uri,
     languageId: string
-  ): prettier.BuiltInParserName | string | undefined {
+  ): Promise<prettier.BuiltInParserName | string | undefined> {
     // This is a workaround for when the vscodeLanguageId is duplicated in multiple
     // prettier languages. In these cases the first match is not the preferred match
     // so we override with the parser that exactly matches the languageId.
@@ -18,7 +18,7 @@ export class LanguageResolver {
     if (uri.scheme === "untitled" && languageParsers.includes(languageId)) {
       return languageId;
     }
-    const language = this.getSupportLanguages(uri.fsPath).find(
+    const language = (await this.getSupportLanguages(uri.fsPath)).find(
       (lang) =>
         lang &&
         lang.extensions &&
@@ -30,9 +30,9 @@ export class LanguageResolver {
     }
   }
 
-  public getSupportedLanguages(fsPath?: string): string[] {
+  public async getSupportedLanguages(fsPath?: string): Promise<string[]> {
     const enabledLanguages: string[] = [];
-    this.getSupportLanguages(fsPath).forEach((lang) => {
+    (await this.getSupportLanguages(fsPath)).forEach((lang) => {
       if (lang && lang.vscodeLanguageIds) {
         enabledLanguages.push(...lang.vscodeLanguageIds);
       }
@@ -53,9 +53,9 @@ export class LanguageResolver {
     ];
   }
 
-  public getSupportedFileExtensions(fsPath?: string) {
+  public async getSupportedFileExtensions(fsPath?: string) {
     const extensions: string[] = [];
-    this.getSupportLanguages(fsPath).forEach((lang) => {
+    (await this.getSupportLanguages(fsPath)).forEach((lang) => {
       if (lang && lang.extensions) {
         extensions.push(...lang.extensions);
       }
@@ -65,8 +65,10 @@ export class LanguageResolver {
     });
   }
 
-  private getSupportLanguages(fsPath?: string) {
-    const prettierInstance = this.moduleResolver.getPrettierInstance(fsPath);
+  private async getSupportLanguages(fsPath?: string) {
+    const prettierInstance = await this.moduleResolver.getPrettierInstance(
+      fsPath
+    );
     return prettierInstance.getSupportInfo().languages;
   }
 }

--- a/src/StatusBarService.ts
+++ b/src/StatusBarService.ts
@@ -52,7 +52,9 @@ export class StatusBarService {
     this.statusBarItem.show();
   }
 
-  private toggleStatusBarItem(editor: TextEditor | undefined): void {
+  private async toggleStatusBarItem(
+    editor: TextEditor | undefined
+  ): Promise<void> {
     if (editor !== undefined) {
       // The function will be triggered every time the active "editor" instance changes
       // It also triggers when we focus on the output panel or on the debug panel
@@ -70,7 +72,7 @@ export class StatusBarService {
         ? undefined
         : editor.document.fileName;
       const score = languages.match(
-        this.languageResolver.getSupportedLanguages(filePath),
+        await this.languageResolver.getSupportedLanguages(filePath),
         editor.document
       );
       const disabledLanguages: PrettierVSCodeConfig["disableLanguages"] = getConfig(

--- a/src/test/suite/ModuleResolver.test.ts
+++ b/src/test/suite/ModuleResolver.test.ts
@@ -51,12 +51,14 @@ suite("Test ModuleResolver", function () {
       );
     });
 
-    test("it returns prettier version from package.json", () => {
+    test("it returns prettier version from package.json", async () => {
       const fileName = path.join(
         getWorkspaceFolderUri("specific-version").fsPath,
         "ugly.js"
       );
-      const prettierInstance = moduleResolver.getPrettierInstance(fileName);
+      const prettierInstance = await moduleResolver.getPrettierInstance(
+        fileName
+      );
 
       assert.notEqual(prettierInstance, prettier);
       assert.equal(prettierInstance.version, "2.0.2");
@@ -69,12 +71,14 @@ suite("Test ModuleResolver", function () {
       );
     });
 
-    test("it returns prettier version from module dep", () => {
+    test("it returns prettier version from module dep", async () => {
       const fileName = path.join(
         getWorkspaceFolderUri("module").fsPath,
         "index.js"
       );
-      const prettierInstance = moduleResolver.getPrettierInstance(fileName);
+      const prettierInstance = await moduleResolver.getPrettierInstance(
+        fileName
+      );
 
       assert.notEqual(prettierInstance, prettier);
       assert.equal(prettierInstance.version, "2.0.2");
@@ -87,13 +91,15 @@ suite("Test ModuleResolver", function () {
       );
     });
 
-    test("it uses explicit dep if found instead fo a closer implicit module dep", () => {
+    test("it uses explicit dep if found instead fo a closer implicit module dep", async () => {
       const fileName = path.join(
         getWorkspaceFolderUri("explicit-dep").fsPath,
         "implicit-dep",
         "index.js"
       );
-      const prettierInstance = moduleResolver.getPrettierInstance(fileName);
+      const prettierInstance = await moduleResolver.getPrettierInstance(
+        fileName
+      );
 
       assert.notEqual(prettierInstance, prettier);
       assert.equal(prettierInstance.version, "2.0.2");

--- a/src/test/suite/ModuleResolver.test.ts
+++ b/src/test/suite/ModuleResolver.test.ts
@@ -23,25 +23,30 @@ suite("Test ModuleResolver", function () {
   });
 
   suite("getPrettierInstance", () => {
-    test("it returns the bundled version of Prettier if local isn't found", () => {
+    test("it returns the bundled version of Prettier if local isn't found", async () => {
       const fileName = path.join(
         getWorkspaceFolderUri("no-dep").fsPath,
         "index.js"
       );
-      const prettierInstance = moduleResolver.getPrettierInstance(fileName, {
-        showNotifications: true,
-      });
+      const prettierInstance = await moduleResolver.getPrettierInstance(
+        fileName,
+        {
+          showNotifications: true,
+        }
+      );
 
       assert.equal(prettierInstance, prettier);
       assert(logInfoSpy.calledWith("Using bundled version of prettier."));
     });
 
-    test("it returns the bundled version of Prettier if local is outdated", () => {
+    test("it returns the bundled version of Prettier if local is outdated", async () => {
       const fileName = path.join(
         getWorkspaceFolderUri("outdated").fsPath,
         "ugly.js"
       );
-      const prettierInstance = moduleResolver.getPrettierInstance(fileName);
+      const prettierInstance = await moduleResolver.getPrettierInstance(
+        fileName
+      );
 
       assert.equal(prettierInstance, prettier);
       assert(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,7 +4,7 @@ type PrettierModule = typeof prettier;
 
 type TrailingCommaOption = "none" | "es5" | "all";
 
-export type PackageManagers = "npm" | "yarn" | "pnpm";
+export type PackageManagers = "auto" | "npm" | "yarn" | "pnpm";
 
 /**
  * prettier-vscode specific configuration

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,7 +4,7 @@ type PrettierModule = typeof prettier;
 
 type TrailingCommaOption = "none" | "es5" | "all";
 
-export type PackageManagers = "auto" | "npm" | "yarn" | "pnpm";
+export type PackageManagers = "npm" | "yarn" | "pnpm";
 
 /**
  * prettier-vscode specific configuration
@@ -26,10 +26,6 @@ interface IExtensionConfig {
    * If true will skip formatting if a prettier config isn't found.
    */
   requireConfig: boolean;
-  /**
-   * The package manager to use when resolving global modules.
-   */
-  packageManager: PackageManagers;
   /**
    * Array of language IDs to ignore
    */


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode/issues/102050

VSCode now automatically detects the package manager by default and exposes the package manager (whether automatically discovered or manually specified in `npm.packageManager` setting) in the `npm.packageManager` command. As a result we can use the `npm.packageManager` command instead of our own `packageManager` setting. By default the Prettier extension will automatically figure out the package manager. Users can still override it with `npm.packageManager`, but the no longer need to also set Prettier's `packageManager` setting.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
