### PR TITLE
Move status bar status indication to left side of Prettier label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [5.9.0]
 - Automatically detect package manager
+- Move check mark in status bar to left side to match ESLint
 
 ## [5.8.0]
 

--- a/src/StatusBarService.ts
+++ b/src/StatusBarService.ts
@@ -48,7 +48,7 @@ export class StatusBarService {
    * @param icon The the icon to use
    */
   public updateStatusBar(result: FormattingResult): void {
-    this.statusBarItem.text = `Prettier: $(${result.toString()})`;
+    this.statusBarItem.text = `$(${result.toString()}) Prettier`;
     this.statusBarItem.show();
   }
 


### PR DESCRIPTION
Fixes #1724

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
