### PR TITLE
Ignore `requirePragma` in forced mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [Unreleased]
+
+- Forced mode now ignores `requirePragma` config
+
 ## [6.3.2]
 
 - Removed loading status bar state

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ graphql
 
 ### Format Document (Forced)
 
-If you would like to format a document that is configured to be ignored by Prettier either because it is in a `.prettierignore` file or part of a normally excluded location like `node_modules`, you can run the command **Format Document (Forced)** to force the document to be formatted.
+If you would like to format a document that is configured to be ignored by Prettier either because it is in a `.prettierignore` file or part of a normally excluded location like `node_modules`, you can run the command **Format Document (Forced)** to force the document to be formatted. Forced mode will also ignore any config for `requirePragma` allowing you to format files without the pragma comment present.
 
 ## Linter Integration
 

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -469,20 +469,12 @@ export default class PrettierEditService implements Disposable {
       return;
     }
 
-    let rangeFormattingOptions: RangeFormattingOptions | undefined;
-    if (options.rangeEnd && options.rangeStart) {
-      rangeFormattingOptions = {
-        rangeEnd: options.rangeEnd,
-        rangeStart: options.rangeStart,
-      };
-    }
-
     const prettierOptions = this.getPrettierOptions(
       fileName,
       parser as prettier.BuiltInParserName,
       vscodeConfig,
       resolvedConfig,
-      rangeFormattingOptions
+      options
     );
 
     this.loggingService.logInfo("Prettier Options:", prettierOptions);
@@ -505,7 +497,7 @@ export default class PrettierEditService implements Disposable {
     parser: prettier.BuiltInParserName,
     vsCodeConfig: prettier.Options,
     configOptions: prettier.Options | null,
-    rangeFormattingOptions?: RangeFormattingOptions
+    extentionFormattingOptions: ExtensionFormattingOptions
   ): Partial<prettier.Options> {
     const fallbackToVSCodeConfig = configOptions === null;
 
@@ -536,6 +528,17 @@ export default class PrettierEditService implements Disposable {
         : "Detected local configuration (i.e. .prettierrc or .editorconfig), VS Code configuration will not be used"
     );
 
+    let rangeFormattingOptions: RangeFormattingOptions | undefined;
+    if (
+      extentionFormattingOptions.rangeEnd &&
+      extentionFormattingOptions.rangeStart
+    ) {
+      rangeFormattingOptions = {
+        rangeEnd: extentionFormattingOptions.rangeEnd,
+        rangeStart: extentionFormattingOptions.rangeStart,
+      };
+    }
+
     const options: prettier.Options = {
       ...(fallbackToVSCodeConfig ? vsOpts : {}),
       ...{
@@ -546,6 +549,10 @@ export default class PrettierEditService implements Disposable {
       ...(rangeFormattingOptions || {}),
       ...(configOptions || {}),
     };
+
+    if (extentionFormattingOptions.force && options.requirePragma === true) {
+      options.requirePragma = false;
+    }
 
     return options;
   }


### PR DESCRIPTION
A feature request with implementation all in one.

## Feature request

**Is your feature request related to a problem? Please describe.**
If my project has `requirePragma: true` set in prettier config, there is currently no way to "force" formatting of the file without first manually adding the pragma comment.

**Describe the solution you'd like**
I would like the recently added "Format Document (Forced)" command to ignore the `requirePragma` setting and format the file anyway. It is called **Forced** after all, shouldn't this action take precedence?

**Describe alternatives you've considered**
I've not really considered other approaches, but open to suggestions on better ways to solve my problem.

## Implementation

We ensure `requirePragma` is `false` if the execution is running in forced mode and `requirePragma` is set `true` in config.

As you can see, I also did a small refactor of `rangeFormattingOptions` as it made the signature for `getPrettierOptions` cleaner.

- [x] Run tests – `it uses config from vscode settings` **fails** for me, but that test also fails on `main`
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
