### PR TITLE
Set ^1.56.0 as VS Code engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/prettier/prettier-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.53.0"
+    "vscode": "^1.56.0"
   },
   "keywords": [
     "multi-root ready",


### PR DESCRIPTION
Fixes #1944

- [x] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
