### PR TITLE
Fix .vscodeignore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - run: npm install -g vsce@1.80.0
+      - run: npm install -g vsce
       - run: vsce package
       - run: echo "VSIX_PATH=$(find . -maxdepth 1 -type f -iname "*.vsix" | head -1)" >> $GITHUB_ENV
       - run: echo "VSIX_NAME=$(basename $(find . -maxdepth 1 -type f -iname "*.vsix" | head -1))" >> $GITHUB_ENV
@@ -74,7 +74,7 @@ jobs:
         with:
           node-version: "14"
       - run: yarn install
-      - run: npm install -g vsce@1.80.0
+      - run: npm install -g vsce
       - run: vsce package
       - run: echo "VSIX_PATH=$(find . -maxdepth 1 -type f -iname "*.vsix" | head -1)" >> $GITHUB_ENV
       - run: echo "VSIX_NAME=$(basename $(find . -maxdepth 1 -type f -iname "*.vsix" | head -1))" >> $GITHUB_ENV

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,7 +17,7 @@ CONTRIBUTORS.md
 CONTRIBUTING.md
 CODE_OF_CONDUCT.md
 
-node_modules
+node_modules/*
 !node_modules/prettier
 !node_modules/spdx-exceptions
 !node_modules/spdx-license-ids

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "sinon": "^11.1.1",
     "ts-loader": "^9.1.2",
     "typescript": "^4.2.4",
-    "vsce": "^1.80.0",
+    "vsce": "^1.93.0",
     "vscode-nls-dev": "^3.3.2",
     "vscode-test": "^1.4.0",
     "webpack": "^5.37.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,7 +971,16 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@^1.0.1, dom-serializer@^1.3.2:
+dom-serializer@^1.0.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.1.tgz#d845a1565d7c041a95e5dab62184ab41e3a519be"
+  integrity sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    entities "^2.0.0"
+
+dom-serializer@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
   integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
@@ -2932,7 +2941,7 @@ vinyl@^2.1.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vsce@^1.80.0:
+vsce@^1.93.0:
   version "1.93.0"
   resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.93.0.tgz#676395f24f27f850f63240b339ed551e2e1d80db"
   integrity sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==


### PR DESCRIPTION
This PR should address the problems that occurred in https://github.com/prettier/prettier-vscode/issues/2013 and https://github.com/prettier/prettier-vscode/issues/2016. The root cause I believe is https://github.com/microsoft/vscode-vsce/issues/576 where [vsce changed how it parses .vscodeignore](https://github.com/microsoft/vscode-vsce/issues/576#issuecomment-855736092). This PR changes it so `node_modules/prettier` is once again included.

**Side note:**
I would like to use this PR to add some additional things that I am unsure of their necessity in the final bundle. I will list these below.
* `.husky/`
* `.nvmrc`

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
