### PR TITLE
chore: replace deprecated vscode-test with @vscode/test-electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/vscode": "^1.57.0",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.28.1",
+    "@vscode/test-electron": "^1.6.1",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.1.0",
     "glob": "^7.1.6",
@@ -105,7 +106,6 @@
     "typescript": "^4.3.5",
     "vsce": "^1.80.0",
     "vscode-nls-dev": "^3.3.2",
-    "vscode-test": "^1.4.0",
     "webpack": "^5.42.0",
     "webpack-cli": "^4.2.0"
   },

--- a/src/test/runTests.ts
+++ b/src/test/runTests.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { runTests } from "vscode-test";
+import { runTests } from "@vscode/test-electron";
 
 async function main() {
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,16 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@vscode/test-electron@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-1.6.1.tgz#2b282154097e250ee9b94b6a284eb5804e53a3d7"
+  integrity sha512-WTs+OK9YrKSVJNZ9IjytNibHSJG2YslZXuS3pw9gedF25TgYF/+FQhQYL0ZPX4uupS0SGAPKzMnhYDkjPDxowA==
+  dependencies:
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    rimraf "^3.0.2"
+    unzipper "^0.10.11"
+
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
@@ -3009,16 +3019,6 @@ vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
-
-vscode-test@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.5.2.tgz#d9ec3cab1815afae1d7d81923e3c685d13d32303"
-  integrity sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==
-  dependencies:
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    rimraf "^3.0.2"
-    unzipper "^0.10.11"
 
 watchpack@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- [x] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md

![2021-07-18 15 55 53](https://user-images.githubusercontent.com/14012511/126060080-8d671595-14c2-43d2-8daa-e8ee579140c3.png)

vscode-test be marked as [deprecated](https://www.npmjs.com/package/vscode-test) on npmjs.org(yarnpkg.com), so just replace vscode-test with latest @vscode/test-electron for `prettier-vscode`'s CI. cc @ntotten 
