### PR TITLE
Fix build following dependency auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,161 +1,161 @@
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "@types/node"
-        versions:
-          - ">= 13.a, < 14"
-      - dependency-name: "@types/node"
-        versions:
-          - ">= 14.a, < 15"
-      - dependency-name: webpack
-        versions:
-          - 5.18.0
-          - 5.19.0
-          - 5.20.0
-          - 5.20.1
-          - 5.21.2
-          - 5.22.0
-          - 5.23.0
-          - 5.24.0
-          - 5.24.1
-          - 5.24.2
-          - 5.24.3
-          - 5.25.1
-          - 5.26.0
-          - 5.26.2
-          - 5.26.3
-          - 5.27.1
-          - 5.27.2
-          - 5.28.0
-          - 5.30.0
-          - 5.31.0
-          - 5.31.2
-          - 5.32.0
-          - 5.34.0
-          - 5.35.0
-          - 5.35.1
-          - 5.36.0
-      - dependency-name: "@types/node"
-        versions:
-          - 12.19.15
-          - 12.20.1
-          - 12.20.10
-          - 12.20.3
-          - 12.20.4
-          - 12.20.6
-          - 12.20.7
-          - 15.0.0
-      - dependency-name: eslint-config-prettier
-        versions:
-          - 7.2.0
-          - 8.0.0
-          - 8.1.0
-          - 8.2.0
-      - dependency-name: ts-loader
-        versions:
-          - 8.0.16
-          - 8.0.17
-          - 9.1.0
-      - dependency-name: "@types/vscode"
-        versions:
-          - 1.54.0
-          - 1.55.0
-      - dependency-name: sinon
-        versions:
-          - 10.0.0
-          - 10.0.1
-      - dependency-name: "@typescript-eslint/parser"
-        versions:
-          - 4.14.1
-          - 4.14.2
-          - 4.15.0
-          - 4.15.1
-          - 4.15.2
-          - 4.16.1
-          - 4.17.0
-          - 4.18.0
-          - 4.19.0
-          - 4.20.0
-          - 4.21.0
-      - dependency-name: "@typescript-eslint/eslint-plugin"
-        versions:
-          - 4.14.1
-          - 4.14.2
-          - 4.15.0
-          - 4.15.1
-          - 4.15.2
-          - 4.16.1
-          - 4.18.0
-          - 4.19.0
-          - 4.20.0
-          - 4.21.0
-      - dependency-name: husky
-        versions:
-          - 5.0.9
-          - 5.1.0
-          - 5.1.1
-          - 5.1.2
-          - 5.1.3
-          - 5.2.0
-          - 6.0.0
-      - dependency-name: vscode-test
-        versions:
-          - 1.5.1
-          - 1.5.2
-      - dependency-name: semver
-        versions:
-          - 7.3.5
-      - dependency-name: "@types/mocha"
-        versions:
-          - 8.2.0
-          - 8.2.1
-          - 8.2.2
-      - dependency-name: "@types/prettier"
-        versions:
-          - 2.2.0
-          - 2.2.3
-      - dependency-name: eslint
-        versions:
-          - 7.18.0
-          - 7.19.0
-          - 7.22.0
-      - dependency-name: vsce
-        versions:
-          - 1.84.0
-          - 1.85.0
-          - 1.86.0
-          - 1.87.0
-      - dependency-name: mocha
-        versions:
-          - 8.3.0
-          - 8.3.1
-          - 8.3.2
-      - dependency-name: typescript
-        versions:
-          - 4.1.4
-          - 4.1.5
-          - 4.2.2
-      - dependency-name: resolve
-        versions:
-          - 1.20.0
-      - dependency-name: lint-staged
-        versions:
-          - 10.5.4
-      - dependency-name: webpack-cli
-        versions:
-          - 4.4.0
-          - 4.5.0
-      - dependency-name: "@types/sinon"
-        versions:
-          - 9.0.10
-      - dependency-name: "@types/resolve"
-        versions:
-          - 1.20.0
-      - dependency-name: "find-up"
-        versions:
-          - ">= 6, < 7"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: "@types/node"
+    versions:
+    - ">= 13.a, < 14"
+  - dependency-name: "@types/node"
+    versions:
+    - ">= 14.a, < 15"
+  - dependency-name: webpack
+    versions:
+    - 5.18.0
+    - 5.19.0
+    - 5.20.0
+    - 5.20.1
+    - 5.21.2
+    - 5.22.0
+    - 5.23.0
+    - 5.24.0
+    - 5.24.1
+    - 5.24.2
+    - 5.24.3
+    - 5.25.1
+    - 5.26.0
+    - 5.26.2
+    - 5.26.3
+    - 5.27.1
+    - 5.27.2
+    - 5.28.0
+    - 5.30.0
+    - 5.31.0
+    - 5.31.2
+    - 5.32.0
+    - 5.34.0
+    - 5.35.0
+    - 5.35.1
+    - 5.36.0
+  - dependency-name: "@types/node"
+    versions:
+    - 12.19.15
+    - 12.20.1
+    - 12.20.10
+    - 12.20.3
+    - 12.20.4
+    - 12.20.6
+    - 12.20.7
+    - 15.0.0
+  - dependency-name: eslint-config-prettier
+    versions:
+    - 7.2.0
+    - 8.0.0
+    - 8.1.0
+    - 8.2.0
+  - dependency-name: ts-loader
+    versions:
+    - 8.0.16
+    - 8.0.17
+    - 9.1.0
+  - dependency-name: "@types/vscode"
+    versions:
+    - 1.54.0
+    - 1.55.0
+  - dependency-name: sinon
+    versions:
+    - 10.0.0
+    - 10.0.1
+  - dependency-name: "@typescript-eslint/parser"
+    versions:
+    - 4.14.1
+    - 4.14.2
+    - 4.15.0
+    - 4.15.1
+    - 4.15.2
+    - 4.16.1
+    - 4.17.0
+    - 4.18.0
+    - 4.19.0
+    - 4.20.0
+    - 4.21.0
+  - dependency-name: "@typescript-eslint/eslint-plugin"
+    versions:
+    - 4.14.1
+    - 4.14.2
+    - 4.15.0
+    - 4.15.1
+    - 4.15.2
+    - 4.16.1
+    - 4.18.0
+    - 4.19.0
+    - 4.20.0
+    - 4.21.0
+  - dependency-name: husky
+    versions:
+    - 5.0.9
+    - 5.1.0
+    - 5.1.1
+    - 5.1.2
+    - 5.1.3
+    - 5.2.0
+    - 6.0.0
+  - dependency-name: vscode-test
+    versions:
+    - 1.5.1
+    - 1.5.2
+  - dependency-name: semver
+    versions:
+    - 7.3.5
+  - dependency-name: "@types/mocha"
+    versions:
+    - 8.2.0
+    - 8.2.1
+    - 8.2.2
+  - dependency-name: "@types/prettier"
+    versions:
+    - 2.2.0
+    - 2.2.3
+  - dependency-name: eslint
+    versions:
+    - 7.18.0
+    - 7.19.0
+    - 7.22.0
+  - dependency-name: vsce
+    versions:
+    - 1.84.0
+    - 1.85.0
+    - 1.86.0
+    - 1.87.0
+  - dependency-name: mocha
+    versions:
+    - 8.3.0
+    - 8.3.1
+    - 8.3.2
+  - dependency-name: typescript
+    versions:
+    - 4.1.4
+    - 4.1.5
+    - 4.2.2
+  - dependency-name: resolve
+    versions:
+    - 1.20.0
+  - dependency-name: lint-staged
+    versions:
+    - 10.5.4
+  - dependency-name: webpack-cli
+    versions:
+    - 4.4.0
+    - 4.5.0
+  - dependency-name: "@types/sinon"
+    versions:
+    - 9.0.10
+  - dependency-name: "@types/resolve"
+    versions:
+    - 1.20.0
+  - dependency-name: "find-up"
+    versions:
+    - ">= 6, < 7"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,158 +1,161 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@types/node"
-    versions:
-    - ">= 13.a, < 14"
-  - dependency-name: "@types/node"
-    versions:
-    - ">= 14.a, < 15"
-  - dependency-name: webpack
-    versions:
-    - 5.18.0
-    - 5.19.0
-    - 5.20.0
-    - 5.20.1
-    - 5.21.2
-    - 5.22.0
-    - 5.23.0
-    - 5.24.0
-    - 5.24.1
-    - 5.24.2
-    - 5.24.3
-    - 5.25.1
-    - 5.26.0
-    - 5.26.2
-    - 5.26.3
-    - 5.27.1
-    - 5.27.2
-    - 5.28.0
-    - 5.30.0
-    - 5.31.0
-    - 5.31.2
-    - 5.32.0
-    - 5.34.0
-    - 5.35.0
-    - 5.35.1
-    - 5.36.0
-  - dependency-name: "@types/node"
-    versions:
-    - 12.19.15
-    - 12.20.1
-    - 12.20.10
-    - 12.20.3
-    - 12.20.4
-    - 12.20.6
-    - 12.20.7
-    - 15.0.0
-  - dependency-name: eslint-config-prettier
-    versions:
-    - 7.2.0
-    - 8.0.0
-    - 8.1.0
-    - 8.2.0
-  - dependency-name: ts-loader
-    versions:
-    - 8.0.16
-    - 8.0.17
-    - 9.1.0
-  - dependency-name: "@types/vscode"
-    versions:
-    - 1.54.0
-    - 1.55.0
-  - dependency-name: sinon
-    versions:
-    - 10.0.0
-    - 10.0.1
-  - dependency-name: "@typescript-eslint/parser"
-    versions:
-    - 4.14.1
-    - 4.14.2
-    - 4.15.0
-    - 4.15.1
-    - 4.15.2
-    - 4.16.1
-    - 4.17.0
-    - 4.18.0
-    - 4.19.0
-    - 4.20.0
-    - 4.21.0
-  - dependency-name: "@typescript-eslint/eslint-plugin"
-    versions:
-    - 4.14.1
-    - 4.14.2
-    - 4.15.0
-    - 4.15.1
-    - 4.15.2
-    - 4.16.1
-    - 4.18.0
-    - 4.19.0
-    - 4.20.0
-    - 4.21.0
-  - dependency-name: husky
-    versions:
-    - 5.0.9
-    - 5.1.0
-    - 5.1.1
-    - 5.1.2
-    - 5.1.3
-    - 5.2.0
-    - 6.0.0
-  - dependency-name: vscode-test
-    versions:
-    - 1.5.1
-    - 1.5.2
-  - dependency-name: semver
-    versions:
-    - 7.3.5
-  - dependency-name: "@types/mocha"
-    versions:
-    - 8.2.0
-    - 8.2.1
-    - 8.2.2
-  - dependency-name: "@types/prettier"
-    versions:
-    - 2.2.0
-    - 2.2.3
-  - dependency-name: eslint
-    versions:
-    - 7.18.0
-    - 7.19.0
-    - 7.22.0
-  - dependency-name: vsce
-    versions:
-    - 1.84.0
-    - 1.85.0
-    - 1.86.0
-    - 1.87.0
-  - dependency-name: mocha
-    versions:
-    - 8.3.0
-    - 8.3.1
-    - 8.3.2
-  - dependency-name: typescript
-    versions:
-    - 4.1.4
-    - 4.1.5
-    - 4.2.2
-  - dependency-name: resolve
-    versions:
-    - 1.20.0
-  - dependency-name: lint-staged
-    versions:
-    - 10.5.4
-  - dependency-name: webpack-cli
-    versions:
-    - 4.4.0
-    - 4.5.0
-  - dependency-name: "@types/sinon"
-    versions:
-    - 9.0.10
-  - dependency-name: "@types/resolve"
-    versions:
-    - 1.20.0
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        versions:
+          - ">= 13.a, < 14"
+      - dependency-name: "@types/node"
+        versions:
+          - ">= 14.a, < 15"
+      - dependency-name: webpack
+        versions:
+          - 5.18.0
+          - 5.19.0
+          - 5.20.0
+          - 5.20.1
+          - 5.21.2
+          - 5.22.0
+          - 5.23.0
+          - 5.24.0
+          - 5.24.1
+          - 5.24.2
+          - 5.24.3
+          - 5.25.1
+          - 5.26.0
+          - 5.26.2
+          - 5.26.3
+          - 5.27.1
+          - 5.27.2
+          - 5.28.0
+          - 5.30.0
+          - 5.31.0
+          - 5.31.2
+          - 5.32.0
+          - 5.34.0
+          - 5.35.0
+          - 5.35.1
+          - 5.36.0
+      - dependency-name: "@types/node"
+        versions:
+          - 12.19.15
+          - 12.20.1
+          - 12.20.10
+          - 12.20.3
+          - 12.20.4
+          - 12.20.6
+          - 12.20.7
+          - 15.0.0
+      - dependency-name: eslint-config-prettier
+        versions:
+          - 7.2.0
+          - 8.0.0
+          - 8.1.0
+          - 8.2.0
+      - dependency-name: ts-loader
+        versions:
+          - 8.0.16
+          - 8.0.17
+          - 9.1.0
+      - dependency-name: "@types/vscode"
+        versions:
+          - 1.54.0
+          - 1.55.0
+      - dependency-name: sinon
+        versions:
+          - 10.0.0
+          - 10.0.1
+      - dependency-name: "@typescript-eslint/parser"
+        versions:
+          - 4.14.1
+          - 4.14.2
+          - 4.15.0
+          - 4.15.1
+          - 4.15.2
+          - 4.16.1
+          - 4.17.0
+          - 4.18.0
+          - 4.19.0
+          - 4.20.0
+          - 4.21.0
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+        versions:
+          - 4.14.1
+          - 4.14.2
+          - 4.15.0
+          - 4.15.1
+          - 4.15.2
+          - 4.16.1
+          - 4.18.0
+          - 4.19.0
+          - 4.20.0
+          - 4.21.0
+      - dependency-name: husky
+        versions:
+          - 5.0.9
+          - 5.1.0
+          - 5.1.1
+          - 5.1.2
+          - 5.1.3
+          - 5.2.0
+          - 6.0.0
+      - dependency-name: vscode-test
+        versions:
+          - 1.5.1
+          - 1.5.2
+      - dependency-name: semver
+        versions:
+          - 7.3.5
+      - dependency-name: "@types/mocha"
+        versions:
+          - 8.2.0
+          - 8.2.1
+          - 8.2.2
+      - dependency-name: "@types/prettier"
+        versions:
+          - 2.2.0
+          - 2.2.3
+      - dependency-name: eslint
+        versions:
+          - 7.18.0
+          - 7.19.0
+          - 7.22.0
+      - dependency-name: vsce
+        versions:
+          - 1.84.0
+          - 1.85.0
+          - 1.86.0
+          - 1.87.0
+      - dependency-name: mocha
+        versions:
+          - 8.3.0
+          - 8.3.1
+          - 8.3.2
+      - dependency-name: typescript
+        versions:
+          - 4.1.4
+          - 4.1.5
+          - 4.2.2
+      - dependency-name: resolve
+        versions:
+          - 1.20.0
+      - dependency-name: lint-staged
+        versions:
+          - 10.5.4
+      - dependency-name: webpack-cli
+        versions:
+          - 4.4.0
+          - 4.5.0
+      - dependency-name: "@types/sinon"
+        versions:
+          - 9.0.10
+      - dependency-name: "@types/resolve"
+        versions:
+          - 1.20.0
+      - dependency-name: "find-up"
+        versions:
+          - ">= 6, < 7"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "webpack-cli": "^4.8.0"
   },
   "dependencies": {
-    "find-up": "^6.0.0",
+    "find-up": "^5.0.0",
     "prettier": "^2.4.1",
     "resolve": "^1.17.0",
     "semver": "^7.3.4",

--- a/src/LoggingService.ts
+++ b/src/LoggingService.ts
@@ -66,7 +66,7 @@ export class LoggingService {
     }
   }
 
-  public logError(message: string, error?: Error | string) {
+  public logError(message: string, error?: unknown) {
     if (this.logLevel === "NONE") {
       return;
     }
@@ -75,7 +75,7 @@ export class LoggingService {
       // Errors as a string usually only happen with
       // plugins that don't return the expected error.
       this.outputChannel.appendLine(error);
-    } else if (error?.message || error?.stack) {
+    } else if (error instanceof Error) {
       if (error?.message) {
         this.logMessage(error.message, "ERROR");
       }

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import * as findUp from "find-up";
+import { findUpStop, findUpSync } from "find-up";
 import * as fs from "fs";
 import * as path from "path";
 import * as prettier from "prettier";
@@ -88,7 +88,7 @@ export class ModuleResolver implements Disposable {
         : this.findPkg(fileName, "prettier");
     } catch (error) {
       let moduleDirectory = "";
-      if (!modulePath) {
+      if (!modulePath && error instanceof Error) {
         // If findPkg threw an error from `resolve.sync`, attempt to parse the
         // directory it failed on to provide a better error message
         const resolveSyncPathRegex = /Cannot find module '.*' from '(.*)'/;
@@ -250,7 +250,7 @@ export class ModuleResolver implements Disposable {
     }
 
     // First look for an explicit package.json dep
-    const packageJsonResDir = findUp.sync(
+    const packageJsonResDir = findUpSync(
       (dir) => {
         if (fs.existsSync(path.join(dir, "package.json"))) {
           let packageJson;
@@ -273,7 +273,7 @@ export class ModuleResolver implements Disposable {
         }
 
         if (this.isInternalTestRoot(dir)) {
-          return findUp.stop;
+          return findUpStop;
         }
       },
       { cwd: finalPath, type: "directory" }
@@ -286,14 +286,14 @@ export class ModuleResolver implements Disposable {
     }
 
     // If no explicit package.json dep found, instead look for implicit dep
-    const nodeModulesResDir = findUp.sync(
+    const nodeModulesResDir = findUpSync(
       (dir) => {
         if (fs.existsSync(path.join(dir, "node_modules", pkgName))) {
           return dir;
         }
 
         if (this.isInternalTestRoot(dir)) {
-          return findUp.stop;
+          return findUpStop;
         }
       },
       { cwd: finalPath, type: "directory" }

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import { findUpStop, findUpSync } from "find-up";
+import * as findUp from "find-up";
 import * as fs from "fs";
 import * as path from "path";
 import * as prettier from "prettier";
@@ -250,7 +250,7 @@ export class ModuleResolver implements Disposable {
     }
 
     // First look for an explicit package.json dep
-    const packageJsonResDir = findUpSync(
+    const packageJsonResDir = findUp.sync(
       (dir) => {
         if (fs.existsSync(path.join(dir, "package.json"))) {
           let packageJson;
@@ -273,7 +273,7 @@ export class ModuleResolver implements Disposable {
         }
 
         if (this.isInternalTestRoot(dir)) {
-          return findUpStop;
+          return findUp.stop;
         }
       },
       { cwd: finalPath, type: "directory" }
@@ -286,14 +286,14 @@ export class ModuleResolver implements Disposable {
     }
 
     // If no explicit package.json dep found, instead look for implicit dep
-    const nodeModulesResDir = findUpSync(
+    const nodeModulesResDir = findUp.sync(
       (dir) => {
         if (fs.existsSync(path.join(dir, "node_modules", pkgName))) {
           return dir;
         }
 
         if (this.isInternalTestRoot(dir)) {
-          return findUpStop;
+          return findUp.stop;
         }
       },
       { cwd: finalPath, type: "directory" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,7 +1350,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -1372,14 +1372,6 @@ find-up@^4.0.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
-
-find-up@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.0.0.tgz#7e321c34ecfea17dfffc4d78017bb025b9dfff71"
-  integrity sha512-NU20P/qRR4fbjbfQgf5SL6L7AbQbUG69OmBJ3o+DEmHwSwKaaeZ+9ok/zuE5Z8pyFSGPerTen16gLZTs1v1zjQ==
-  dependencies:
-    locate-path "^7.0.0"
-    path-exists "^5.0.0"
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -1911,13 +1903,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-locate-path@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.0.0.tgz#f0a60c8dd7ef0f737699eb9461b9567a92bc97da"
-  integrity sha512-+cg2yXqDUKfo4hsFxwa3G1cBJeA+gs1vD8FyV9/odWoUlQe/4syxHQ5DPtKjtfm6gnKbZzjCqzX03kXosvZB1w==
-  dependencies:
-    p-locate "^6.0.0"
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -2207,13 +2192,6 @@ p-limit@^3.0.2, p-limit@^3.1.0:
   dependencies:
     yocto-queue "^0.1.0"
 
-p-limit@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
-  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
-  dependencies:
-    yocto-queue "^1.0.0"
-
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
@@ -2234,13 +2212,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-p-locate@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
-  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
-  dependencies:
-    p-limit "^4.0.0"
 
 p-map@^4.0.0:
   version "4.0.0"
@@ -2304,11 +2275,6 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-exists@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
-  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -3314,8 +3280,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-yocto-queue@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
-  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==


### PR DESCRIPTION
- [x] Run tests
- [ ] ~~Update the [`CHANGELOG.md`][1] with a summary of your changes~~
    Not applicable because the changes only clean-up dependency auto-updates

This PR solves two problems which prevent the extension from building in the `main` branch.

- The first is related to changes in `try/catch` typings, which [converted `error` from `any` to `unknown`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables).

- The other issue was to do with `find-up`, which got upgraded from v5 to v6 in #2191. The latest version uses [`import path from 'node:path'`](https://github.com/sindresorhus/find-up/blob/ace3d10aadce889a78924954a2766af81eb315ff/index.js#L1), which does not work in Node 14.7.6-, [according to `is-core-module`](https://github.com/inspect-js/is-core-module/blob/6717f000d063ea57beb772bded36c2f056ac404c/core.json#L71). I reverted `find-up` to v5 and prevented further auto-upgrades to v6.

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md

