### PR TITLE
Use HTTPS URLs for schemastore.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [9.0.1]
+
+- Changed schemastore.com URLs to use HTTPS
+
 ## [9.0.0]
 
 - Support for browser VS Code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ Feel free to open issues or PRs!
 ## Running extension
 
 - Open this repository inside VSCode
+- `yarn install`
 - Debug sidebar
-- `Launch Extension`
+- `Run Extension`
 
 ## Running tests
 

--- a/package-json-schema.json
+++ b/package-json-schema.json
@@ -3,7 +3,7 @@
   "properties": {
     "prettier": {
       "description": "Prettier configuration",
-      "$ref": "http://json.schemastore.org/prettierrc"
+      "$ref": "https://json.schemastore.org/prettierrc"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -376,11 +376,11 @@
     "jsonValidation": [
       {
         "fileMatch": ".prettierrc",
-        "url": "http://json.schemastore.org/prettierrc"
+        "url": "https://json.schemastore.org/prettierrc"
       },
       {
         "fileMatch": ".prettierrc.json",
-        "url": "http://json.schemastore.org/prettierrc"
+        "url": "https://json.schemastore.org/prettierrc"
       },
       {
         "fileMatch": "package.json",


### PR DESCRIPTION
This PR changes the schemastore.com URLs to use HTTPS to prevent MitM attacks. Should not cause issues with firewalls since other schemastore.com files in VS Code are also loaded with HTTPS.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
