### PR TITLE
Remove .gts and .gjs from Handlebars extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## Unreleased
+
+- Remove `.gts` and `.gjs` from Handlebars extensions
+
 ## [9.2.0]
 
 - Clear cache on reload (#2371)

--- a/package.json
+++ b/package.json
@@ -419,8 +419,6 @@
         "id": "handlebars",
         "extensions": [
           ".hbs",
-          ".gjs",
-          ".gts",
           ".handlebars"
         ]
       }


### PR DESCRIPTION
- [x] Run tests
- [x] Update the `CHANGELOG.md` with a summary of your changes

The `.gts` and `.gjs` extensions are proposed file formats for the Ember.js ecosystem that allow embedding Glimmer/Handlebars documents directly in TS and JS files, but they themselves aren't actually Handlebars. If the proposal moves forward, the community will likely invest in teaching tooling like Prettier how the nesting in these documents works, but for now we shouldn't treat them as vanilla Handlebars, since that causes Code to also use Handlebars syntax highlighting, etc, which is incorrect.

I chatted with @lifeart who got the Handlebars support landed a few weeks ago (hurray!) and he's on board with this change.