### PR TITLE
Generate the config file using the extension settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 ## Unreleased
 
 - Remove `.gts` and `.gjs` from Handlebars extensions
+- Changed the initial contents of a newly generated config file to use the extension settings defined in VSCode
 
 ## [9.2.0]
 

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -24,7 +24,11 @@ import {
   PrettierOptions,
   RangeFormattingOptions,
 } from "./types";
-import { getConfig, getWorkspaceRelativePath } from "./util";
+import {
+  getConfig,
+  getWorkspaceRelativePath,
+  filterFormattingOptions,
+} from "./util";
 
 interface ISelectors {
   rangeLanguageSelector: ReadonlyArray<DocumentFilter>;
@@ -454,23 +458,7 @@ export default class PrettierEditService implements Disposable {
 
     const vsOpts: PrettierOptions = {};
     if (fallbackToVSCodeConfig) {
-      vsOpts.arrowParens = vsCodeConfig.arrowParens;
-      vsOpts.bracketSpacing = vsCodeConfig.bracketSpacing;
-      vsOpts.endOfLine = vsCodeConfig.endOfLine;
-      vsOpts.htmlWhitespaceSensitivity = vsCodeConfig.htmlWhitespaceSensitivity;
-      vsOpts.insertPragma = vsCodeConfig.insertPragma;
-      vsOpts.jsxBracketSameLine = vsCodeConfig.jsxBracketSameLine;
-      vsOpts.jsxSingleQuote = vsCodeConfig.jsxSingleQuote;
-      vsOpts.printWidth = vsCodeConfig.printWidth;
-      vsOpts.proseWrap = vsCodeConfig.proseWrap;
-      vsOpts.quoteProps = vsCodeConfig.quoteProps;
-      vsOpts.requirePragma = vsCodeConfig.requirePragma;
-      vsOpts.semi = vsCodeConfig.semi;
-      vsOpts.singleQuote = vsCodeConfig.singleQuote;
-      vsOpts.tabWidth = vsCodeConfig.tabWidth;
-      vsOpts.trailingComma = vsCodeConfig.trailingComma;
-      vsOpts.useTabs = vsCodeConfig.useTabs;
-      vsOpts.vueIndentScriptAndStyle = vsCodeConfig.vueIndentScriptAndStyle;
+      Object.assign(vsOpts, filterFormattingOptions(vsCodeConfig));
     }
 
     this.loggingService.logInfo(

--- a/src/TemplateService.ts
+++ b/src/TemplateService.ts
@@ -2,6 +2,7 @@ import { TextEncoder } from "util";
 import { Uri, workspace } from "vscode";
 import { LoggingService } from "./LoggingService";
 import { PrettierModule, PrettierOptions } from "./types";
+import { filterFormattingOptions, getConfig } from "./util";
 
 export class TemplateService {
   constructor(
@@ -9,7 +10,12 @@ export class TemplateService {
     private prettierModule: PrettierModule
   ) {}
   public async writeConfigFile(folderPath: Uri) {
-    const settings = { tabWidth: 2, useTabs: false };
+    const vsCodeConfig = getConfig();
+    const settings = {
+      tabWidth: 2,
+      useTabs: false,
+      ...filterFormattingOptions(vsCodeConfig),
+    };
 
     const outputPath = Uri.joinPath(folderPath, ".prettierrc");
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import * as os from "os";
 import * as path from "path";
 import { Uri, workspace } from "vscode";
-import { PrettierVSCodeConfig } from "./types";
+import { PrettierVSCodeConfig, PrettierOptions } from "./types";
 
 export function getWorkspaceRelativePath(
   filePath: string,
@@ -50,4 +50,30 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
   }
 
   return config;
+}
+
+export function filterFormattingOptions(
+  vsCodeConfig: PrettierOptions
+): PrettierOptions {
+  const formattingOptions: PrettierOptions = {
+    arrowParens: vsCodeConfig.arrowParens,
+    bracketSpacing: vsCodeConfig.bracketSpacing,
+    endOfLine: vsCodeConfig.endOfLine,
+    htmlWhitespaceSensitivity: vsCodeConfig.htmlWhitespaceSensitivity,
+    insertPragma: vsCodeConfig.insertPragma,
+    jsxBracketSameLine: vsCodeConfig.jsxBracketSameLine,
+    jsxSingleQuote: vsCodeConfig.jsxSingleQuote,
+    printWidth: vsCodeConfig.printWidth,
+    proseWrap: vsCodeConfig.proseWrap,
+    quoteProps: vsCodeConfig.quoteProps,
+    requirePragma: vsCodeConfig.requirePragma,
+    semi: vsCodeConfig.semi,
+    singleQuote: vsCodeConfig.singleQuote,
+    tabWidth: vsCodeConfig.tabWidth,
+    trailingComma: vsCodeConfig.trailingComma,
+    useTabs: vsCodeConfig.useTabs,
+    vueIndentScriptAndStyle: vsCodeConfig.vueIndentScriptAndStyle,
+  };
+
+  return formattingOptions;
 }


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

---

Currently, the `"Create Configuration File"` command generates a config file with only 2 hard-coded rules (`tabWidth` & `useTabs`).

This PR changes the initial content the command uses to generate the config file so that it uses the formatting rules defined in the VSCode settings. This way, if a user has customized their default Prettier settings in VSCode, those will also be used as a starting point when generating a `.prettierrc` file in a new project.

Alternatively, if you prefer not to change the behavior of the existing command, an additional command could be added that explicitly generates the file using the VSCode settings (A bit too verbose IMO, but maybe something like `"Create Configuration File Using the Extension's Settings"`?).

What do you think?

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
