### PR TITLE
fix: remove extraneous messages

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -2,13 +2,10 @@ export const OUTDATED_PRETTIER_VERSION_MESSAGE =
   "Your project is configured to use an outdated version of prettier that cannot be used by this extension. Upgrade to the latest version of prettier.";
 export const INVALID_PRETTIER_PATH_MESSAGE =
   "`prettierPath` option does not reference a valid instance of Prettier. Please ensure you are passing a path to the prettier module, not the binary. Falling back to bundled version of prettier.";
-export const VIEW_LOGS_ACTION_TEXT = "Show Log";
 export const FAILED_TO_LOAD_MODULE_MESSAGE =
   "Failed to load module. If you have prettier or plugins referenced in package.json, ensure you have run `npm install`";
 export const INVALID_PRETTIER_CONFIG =
   "Invalid prettier configuration file detected. See log for details.";
-export const UNABLE_TO_LOAD_PRETTIER =
-  "Unable to load the configured Prettier module. Prettier will not run. Check logs.";
 export const RESTART_TO_ENABLE =
   "To enable or disable prettier after changing the `enable` setting, you must restart VS Code.";
 export const USING_BUNDLED_PRETTIER = "Using bundled version of prettier.";


### PR DESCRIPTION
Hello

These 2 constants are not referenced anywhere in the codebase anymore.

They are left-overs dating back from the removal of the NotificationService in https://github.com/prettier/prettier-vscode/commit/899e952fb9aff34699e4f22470394c711a81eb86

Thanks.
