### PR TITLE
fix misspellings

### DIFF
--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -179,7 +179,7 @@ export default class PrettierEditService implements Disposable {
     );
 
     // If there isn't an instance here, it is because the module
-    // could not be loaded either locally or globably when specified
+    // could not be loaded either locally or globally when specified
     if (!prettierInstance) {
       this.statusBar.update(FormatterStatus.Error);
       return;
@@ -476,7 +476,7 @@ export default class PrettierEditService implements Disposable {
     parser: PrettierBuiltInParserName,
     vsCodeConfig: PrettierOptions,
     configOptions: PrettierOptions | null,
-    extentionFormattingOptions: ExtensionFormattingOptions
+    extensionFormattingOptions: ExtensionFormattingOptions
   ): Partial<PrettierOptions> {
     const fallbackToVSCodeConfig = configOptions === null;
 
@@ -509,12 +509,12 @@ export default class PrettierEditService implements Disposable {
 
     let rangeFormattingOptions: RangeFormattingOptions | undefined;
     if (
-      extentionFormattingOptions.rangeEnd &&
-      extentionFormattingOptions.rangeStart
+      extensionFormattingOptions.rangeEnd &&
+      extensionFormattingOptions.rangeStart
     ) {
       rangeFormattingOptions = {
-        rangeEnd: extentionFormattingOptions.rangeEnd,
-        rangeStart: extentionFormattingOptions.rangeStart,
+        rangeEnd: extensionFormattingOptions.rangeEnd,
+        rangeStart: extensionFormattingOptions.rangeStart,
       };
     }
 
@@ -529,7 +529,7 @@ export default class PrettierEditService implements Disposable {
       ...(configOptions || {}),
     };
 
-    if (extentionFormattingOptions.force && options.requirePragma === true) {
+    if (extensionFormattingOptions.force && options.requirePragma === true) {
       options.requirePragma = false;
     }
 


### PR DESCRIPTION
- [ ] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
