### PR TITLE
Add extra registered lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## Unreleased
+
+- Register `mongodb` in `vscodeLanguageIds` to support formatting mongodb queries in VS Code
+
 ## [9.5.0]
 
 - Fix `"editor.formatOnSaveMode": "modifications"`/`"modificationsIfAvailable"`

--- a/src/BrowserModuleResolver.ts
+++ b/src/BrowserModuleResolver.ts
@@ -61,7 +61,12 @@ export class ModuleResolver implements ModuleResolverInterface {
         return {
           languages: [
             {
-              vscodeLanguageIds: ["javascript", "mongo", "javascriptreact"],
+              vscodeLanguageIds: [
+                "javascript",
+                "javascriptreact",
+                "mongo",
+                "mongodb",
+              ],
               extensions: [],
               parsers: [
                 "babel",


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.m

Here is an official mongodb language server [index](https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode), [repo](https://github.com/mongodb-js/vscode). And this extension register `mongodb` filename extension for mongodb query which actually is just a js file [Source code](https://github.com/mongodb-js/vscode/blob/ed24e886cb2731820cdc51e7bc54b23a0b176061/package.json#L125-L135).

We can just associate `*.mongodb` as `javascript` file in VS Code settings, but it would lost language server feature provided from mongo extension. Or use `.prettierrc` to custom parser and format files by force. Seems still inconvenienced.

Currently, we still cannot natively format `*.mongodb` file via `prettier-vscode`. This PR add a new `mongodb` item to `vscodeLanguageIds`.

Attached file: [runTests.log](https://github.com/prettier/prettier-vscode/files/8580333/runTests.log)