### PR TITLE
Fix support for using a globally installed version of prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 - Search for ignore file in all containing workspace folders, not just innermost
 - Fix wrong time unit in log.
 - Allow formatting ranges in `jsonc` (JSON with Comments).
+- Fix support for using a globally installed version of prettier.
 
 ## [9.5.0]
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,9 @@
     "semver": "^7.3.7",
     "vscode-nls": "^5.0.0"
   },
+  "extensionDependencies": [
+    "vscode.npm"
+  ],
   "capabilities": {
     "virtualWorkspaces": true,
     "untrustedWorkspaces": {

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -128,9 +128,14 @@ export class ModuleResolver implements ModuleResolverInterface {
 
     // If global modules allowed, look for global module
     if (resolveGlobalModules && !modulePath) {
+      let workspaceFolder;
+      if (workspace.workspaceFolders) {
+        const folder = workspace.getWorkspaceFolder(Uri.file(fileName));
+        if (folder) workspaceFolder = folder.uri;
+      }
       const packageManager = (await commands.executeCommand<
         "npm" | "pnpm" | "yarn"
-      >("npm.packageManager"))!;
+      >("npm.packageManager", workspaceFolder))!;
       const resolvedGlobalPackageManagerPath = globalPathGet(packageManager);
       if (resolvedGlobalPackageManagerPath) {
         const globalModulePath = path.join(


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

The extension's support for using a globally installed version of prettier wasn't working for me. I looked into it and found that command `npm.packageManager` was returning an empty value. It appears that you're actually supposed to pass the workspace folder URI as a parameter for this command to work!

While working on this pull request I also noticed that I was getting the error `command 'npm.packageManager' not found`. It appears this command comes from the `npm` extension. The extension is built into vscode, but for some reason it didn't get loaded. I found that adding this extension to the `extensionDependencies` section in `package.json` made the error go away.

Running the tests locally I get a few errors, but I get the same errors without my changes so I don't think they're related.

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
