### PR TITLE
Upgrade `prettier` to the latest stable version `2.7.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 - Fix wrong time unit in log.
 - Allow formatting ranges in `jsonc` (JSON with Comments).
 
+## [9.6.0]
+
+- Upgraded Prettier to the [latest stable](https://prettier.io/versions.html) version `2.7.1`
+
 ## [9.5.0]
 
 - Fix `"editor.formatOnSaveMode": "modifications"`/`"modificationsIfAvailable"`

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "dependencies": {
     "find-up": "5.0.0",
-    "prettier": "^2.6.1",
+    "prettier": "^2.7.1",
     "resolve": "^1.22.0",
     "semver": "^7.3.7",
     "vscode-nls": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,10 +3187,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
-  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -3453,13 +3453,6 @@ semver@^5.1.0, semver@^5.4.1:
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Updates `prettier` to the latest stable version `2.7.1`
- Bumps the version of the plugin to `9.6.0`

### Checks
- [x] Run tests
    - All tests are passing :tada:
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes


[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
