### PR TITLE
Fix: Prettier doesn't support range formatting for Vue and Handlebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 - Use config from `.prettierrc` when formatting VS Code user `settings.json`. Fixes [[#2226](https://github.com/prettier/prettier-vscode/issues/2226)].
 - Improved support for pnpm ([@fz6m](https://github.com/fz6m))
 - Improved support for global modules ([@ehoogeveen-medweb](https://github.com/ehoogeveen-medweb))
+- Disallow range formatting for Vue and Handlebars as Prettier doesn't support that
 
 ## [9.7.0]
 

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -64,8 +64,6 @@ export default class PrettierEditService implements Disposable {
     "json",
     "jsonc",
     "graphql",
-    "handlebars",
-    "vue",
   ];
 
   constructor(


### PR DESCRIPTION
See https://github.com/prettier/prettier/issues/13399

- [ ] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md