### PR TITLE
Do not ship `.devcontainer` folder

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.devcontainer/
 .github/
 .husky/
 .vscode/


### PR DESCRIPTION
Currently `.devcontainer` folder is not included in `.vscodeignore`, hence it is shipped with the extension.
