### PR TITLE
Drop extension dependency on vscode.npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,9 +131,6 @@
     "semver": "^7.3.8",
     "vscode-nls": "^5.2.0"
   },
-  "extensionDependencies": [
-    "vscode.npm"
-  ],
   "capabilities": {
     "virtualWorkspaces": true,
     "untrustedWorkspaces": {


### PR DESCRIPTION
Admittedly I don't know for sure this doesn't break. But.. On a quick scan through the code, I'm not seeing the dependency.....

(This is more of a bug report in the form of a PR.. :)

#### Complete story:

vscode has been giving me this error recently while working on [lighthouse](https://github.com/GoogleChrome/lighthouse): 
<img width="475" alt="image" src="https://user-images.githubusercontent.com/39191/222568118-5e20bc30-2df6-4fe1-953f-2474069d85a7.png">

I don't have multiple lockfiles locally, so the error is wrong. But more importantly... I was surprised to see this 'npm support for vscode' extension active, as I don't want it and don't have it directly installed. I soon realized it's installed via the dependency of Prettier.

If you are not making use of this depedency, let's delete?

If you _are_ making use of it.. Where?  scripts of my project seem irrelevant to how prettier engages with it.. Maybe it shouldn't? :)

-------------

Obviously I don't have the full picture, so apologies for being so direct. But I didn't see any previous discussion. Cheers! (And thank you for the extension. It's a peach!)
