### PR TITLE
Add config fallback for embeddedLanguageFormatting

### DIFF
--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -506,6 +506,8 @@ export default class PrettierEditService implements Disposable {
       vsOpts.tabWidth = vsCodeConfig.tabWidth;
       vsOpts.trailingComma = vsCodeConfig.trailingComma;
       vsOpts.useTabs = vsCodeConfig.useTabs;
+      vsOpts.embeddedLanguageFormatting =
+        vsCodeConfig.embeddedLanguageFormatting;
       vsOpts.vueIndentScriptAndStyle = vsCodeConfig.vueIndentScriptAndStyle;
     }
 


### PR DESCRIPTION
I have noticed that `embeddedLanguageFormatting` is missing from the fallback logic of the VSCode configuration. Therefore, I am submitting a pull request to add this missing feature.

This fix should help all users who have set this option in their `settings.json` but have not seen the expected behavior. In other words, the formatting of VSCode's built-in language will now work as intended.

- [x]  Run tests
- [ ] Update the [`CHANGELOG.md`](https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md) with a summary of your changes