### PR TITLE
Print more error details for debugging and use node 14 for windows tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,13 @@ jobs:
           run_install: false
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        if: runner.os != 'Windows'
         with:
           node-version-file: ".nvmrc"
+      - uses: actions/setup-node@v3
+        if: runner.os == 'Windows'
+        with:
+          node-version: 14
       - run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & echo "Started xvfb"
         shell: bash
         if: ${{ success() && matrix.os == 'ubuntu-latest' }}
@@ -44,8 +49,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        if: runner.os != 'Windows'
         with:
           node-version-file: ".nvmrc"
+      - uses: actions/setup-node@v3
+        if: runner.os == 'Windows'
+        with:
+          node-version: 14
       - run: yarn install
       - name: Cache node modules
         uses: actions/cache@v3
@@ -75,8 +85,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        if: runner.os != 'Windows'
         with:
           node-version-file: ".nvmrc"
+      - uses: actions/setup-node@v3
+        if: runner.os == 'Windows'
+        with:
+          node-version: 14
       - run: yarn install
       - run: npm install -g vsce
       - run: vsce package

--- a/src/test/runTests.ts
+++ b/src/test/runTests.ts
@@ -57,8 +57,16 @@ async function main() {
         .concat(["--user-data-dir", userDataDirectory]),
     });
   } catch (error) {
-    // eslint-disable-next-line no-console
+    /* eslint-disable no-console */
     console.error("Failed to run tests");
+    if (error instanceof Error) {
+      console.error("error message: " + error.message);
+      console.error("error name: " + error.name);
+      console.error("error stack: " + error.stack);
+    } else {
+      console.error("No error object: " + JSON.stringify(error));
+    }
+    /* eslint-enable no-console */
     process.exit(1);
   }
 }


### PR DESCRIPTION
https://github.com/prettier/prettier-vscode/commit/822ad24288650fdb841c3d9b449d8984118bf3dd makes GitHub Actions refer `.nvmrc` when `setup-node`. 

However, since then the windows test has been failing. This is because the windows test does not work on node 18. In this PR, we will use node 14 only for windows testing.

Ideally, windows tests should also use the latest node, but that will be addressed in another PR.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
