### PR TITLE
Resolve config before call `getSupportInfo` for v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "scripts": {
     "clean": "node ./scripts/clean.js",
     "lint": "eslint -c .eslintrc.js --ext .ts .",
-    "pretest": "yarn test-compile && cd test-fixtures/plugins && yarn install && cd ../plugins-pnpm && pnpm i && cd ../outdated && yarn install && cd ../module && yarn install && cd ../specific-version && yarn install && cd ../explicit-dep && yarn install && cd implicit-dep && yarn install && cd ../../v3 && yarn install && cd ../plugin-tailwindcss && npm i",
+    "pretest": "yarn test-compile && cd test-fixtures/plugins && yarn install && cd ../plugins-pnpm && pnpm i && cd ../outdated && yarn install && cd ../module && yarn install && cd ../specific-version && yarn install && cd ../explicit-dep && yarn install && cd implicit-dep && yarn install && cd ../../v3 && yarn install && cd ../plugin-tailwindcss && npm i && cd ../v3-plugins && npm i",
     "prettier": "prettier --write '**/*.{ts,json,md,hbs,yml,js}'",
     "test-compile": "yarn clean && tsc -p ./ && yarn webpack && cp -r ./src/worker ./out",
     "test": "node ./out/test/runTests.js",

--- a/src/BrowserModuleResolver.ts
+++ b/src/BrowserModuleResolver.ts
@@ -26,9 +26,10 @@ import * as yamlPlugin from "prettier/parser-yaml";
 //import * as flowPlugin from "prettier/parser-flow";
 //import * as postcssPlugin from "prettier/parser-postcss";
 
-import { TextDocument } from "vscode";
+import { TextDocument, Uri } from "vscode";
 import { LoggingService } from "./LoggingService";
 import { getWorkspaceRelativePath } from "./util";
+import { ResolveConfigOptions, Options } from "prettier";
 
 const plugins = [
   angularPlugin,
@@ -172,6 +173,25 @@ export class ModuleResolver implements ModuleResolverInterface {
         return { ignored: false, inferredParser: null };
       },
     };
+  }
+
+  async resolveConfig(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    prettierInstance: {
+      resolveConfigFile(filePath?: string | undefined): Promise<string | null>;
+      resolveConfig(
+        fileName: string,
+        options?: ResolveConfigOptions | undefined
+      ): Promise<Options | null>;
+    },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    uri: Uri,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    fileName: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    vscodeConfig: PrettierVSCodeConfig
+  ): Promise<Options | "error" | "disabled" | null> {
+    return null;
   }
 
   async getResolvedConfig(

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -1,3 +1,6 @@
+import * as path from "path";
+import { PrettierOptions } from "./types";
+
 declare const __webpack_require__: typeof require;
 declare const __non_webpack_require__: typeof require;
 
@@ -25,4 +28,27 @@ export function resolveNodeModule(
   } catch (error) {
     throw new Error(`Error resolve node module '${moduleName}'`);
   }
+}
+
+/**
+ * Resolve plugin package path for symlink structure dirs
+ * See https://github.com/prettier/prettier/issues/8056
+ */
+export function resolveConfigPlugins(
+  config: PrettierOptions,
+  fileName: string
+): PrettierOptions {
+  if (config?.plugins?.length) {
+    config.plugins = config.plugins.map((plugin) => {
+      if (
+        typeof plugin === "string" &&
+        !plugin.startsWith(".") &&
+        !path.isAbsolute(plugin)
+      ) {
+        return resolveNodeModule(plugin, { paths: [fileName] }) || plugin;
+      }
+      return plugin;
+    });
+  }
+  return config;
 }

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -15,3 +15,14 @@ export function loadNodeModule<T>(moduleName: string): T | undefined {
     throw new Error(`Error loading node module '${moduleName}'`);
   }
 }
+
+export function resolveNodeModule(
+  moduleName: string,
+  options?: { paths: string[] }
+) {
+  try {
+    return nodeModuleLoader().resolve(moduleName, options);
+  } catch (error) {
+    throw new Error(`Error resolve node module '${moduleName}'`);
+  }
+}

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -331,9 +331,13 @@ export class ModuleResolver implements ModuleResolverInterface {
     const isVirtual = uri.scheme !== "file" && uri.scheme !== "vscode-userdata";
 
     let configPath: string | undefined;
+    let prettierInstance: typeof prettier | PrettierInstance = prettier;
     try {
       if (!isVirtual) {
-        configPath = (await prettier.resolveConfigFile(fileName)) ?? undefined;
+        prettierInstance =
+          (await this.getPrettierInstance(fileName)) || prettierInstance;
+        configPath =
+          (await prettierInstance.resolveConfigFile(fileName)) ?? undefined;
       }
     } catch (error) {
       this.loggingService.logError(
@@ -357,7 +361,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     try {
       resolvedConfig = isVirtual
         ? null
-        : await prettier.resolveConfig(fileName, resolveConfigOptions);
+        : await prettierInstance.resolveConfig(fileName, resolveConfigOptions);
     } catch (error) {
       this.loggingService.logError(
         "Invalid prettier configuration file detected.",

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -27,7 +27,7 @@ import { getConfig, getWorkspaceRelativePath } from "./util";
 import { PrettierWorkerInstance } from "./PrettierWorkerInstance";
 import { PrettierInstance } from "./PrettierInstance";
 import { PrettierMainThreadInstance } from "./PrettierMainThreadInstance";
-import { loadNodeModule, nodeModuleLoader } from "./ModuleLoader";
+import { loadNodeModule, resolveNodeModule } from "./ModuleLoader";
 
 const minPrettierVersion = "1.13.0";
 
@@ -410,18 +410,6 @@ export class ModuleResolver implements ModuleResolverInterface {
     this.path2Module.clear();
   }
 
-  private resolveNodeModule(moduleName: string, options?: { paths: string[] }) {
-    try {
-      return nodeModuleLoader().resolve(moduleName, options);
-    } catch (error) {
-      this.loggingService.logError(
-        `Error resolve node module '${moduleName}'`,
-        error
-      );
-    }
-    return undefined;
-  }
-
   /**
    * Resolve plugin package path for symlink structure dirs
    * See https://github.com/prettier/prettier/issues/8056
@@ -437,9 +425,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           !plugin.startsWith(".") &&
           !path.isAbsolute(plugin)
         ) {
-          return (
-            this.resolveNodeModule(plugin, { paths: [fileName] }) || plugin
-          );
+          return resolveNodeModule(plugin, { paths: [fileName] }) || plugin;
         }
         return plugin;
       });

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -399,7 +399,8 @@ export class ModuleResolver implements ModuleResolverInterface {
     { fileName, uri }: TextDocument,
     vscodeConfig: PrettierVSCodeConfig
   ): Promise<"error" | "disabled" | PrettierOptions | null> {
-    const prettierInstance: typeof prettier | PrettierInstance = prettier;
+    const prettierInstance: typeof prettier | PrettierInstance =
+      (await this.getPrettierInstance(fileName)) || prettier;
 
     const resolvedConfig = await this.resolveConfig(
       prettierInstance,

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -26,6 +26,7 @@ import {
 } from "./types";
 import { getConfig } from "./util";
 import { PrettierInstance } from "./PrettierInstance";
+import { resolveNodeModule } from "./ModuleLoader";
 
 interface ISelectors {
   rangeLanguageSelector: ReadonlyArray<DocumentFilter>;
@@ -256,8 +257,9 @@ export default class PrettierEditService implements Disposable {
     prettierInstance: PrettierModule | PrettierInstance,
     uri?: Uri
   ): Promise<ISelectors> => {
+    const plugins: string[] = [];
     const { languages } = await prettierInstance.getSupportInfo({
-      plugins: [],
+      plugins,
     });
 
     languages.forEach((lang) => {

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -256,7 +256,9 @@ export default class PrettierEditService implements Disposable {
     prettierInstance: PrettierModule | PrettierInstance,
     uri?: Uri
   ): Promise<ISelectors> => {
-    const { languages } = await prettierInstance.getSupportInfo();
+    const { languages } = await prettierInstance.getSupportInfo({
+      plugins: [],
+    });
 
     languages.forEach((lang) => {
       if (lang && lang.vscodeLanguageIds) {
@@ -444,7 +446,9 @@ export default class PrettierEditService implements Disposable {
       this.loggingService.logWarning(
         `Parser not inferred, trying VS Code language.`
       );
-      const { languages } = await prettierInstance.getSupportInfo();
+      const { languages } = await prettierInstance.getSupportInfo({
+        plugins: [],
+      });
       parser = getParserFromLanguageId(languages, uri, languageId);
     }
 

--- a/src/PrettierInstance.ts
+++ b/src/PrettierInstance.ts
@@ -13,7 +13,7 @@ export interface PrettierInstance {
     filePath: string,
     fileInfoOptions?: PrettierFileInfoOptions
   ): Promise<PrettierFileInfoResult>;
-  getSupportInfo(): Promise<{
+  getSupportInfo({ plugins }: { plugins: string[] }): Promise<{
     languages: PrettierSupportLanguage[];
   }>;
   clearConfigCache(): Promise<void>;

--- a/src/PrettierInstance.ts
+++ b/src/PrettierInstance.ts
@@ -1,7 +1,9 @@
+import { ResolveConfigOptions } from "prettier";
 import {
   PrettierFileInfoOptions,
   PrettierFileInfoResult,
   PrettierOptions,
+  PrettierPlugin,
   PrettierSupportLanguage,
 } from "./types";
 
@@ -13,10 +15,19 @@ export interface PrettierInstance {
     filePath: string,
     fileInfoOptions?: PrettierFileInfoOptions
   ): Promise<PrettierFileInfoResult>;
-  getSupportInfo({ plugins }: { plugins: string[] }): Promise<{
+  getSupportInfo({
+    plugins,
+  }: {
+    plugins: (string | PrettierPlugin)[];
+  }): Promise<{
     languages: PrettierSupportLanguage[];
   }>;
   clearConfigCache(): Promise<void>;
+  resolveConfigFile(filePath?: string): Promise<string | null>;
+  resolveConfig(
+    fileName: string,
+    options?: ResolveConfigOptions
+  ): Promise<PrettierOptions | null>;
 }
 
 export interface PrettierInstanceConstructor {

--- a/src/PrettierMainThreadInstance.ts
+++ b/src/PrettierMainThreadInstance.ts
@@ -44,13 +44,14 @@ export const PrettierMainThreadInstance: PrettierInstanceConstructor = class Pre
     return this.prettierModule!.getFileInfo(filePath, fileInfoOptions);
   }
 
-  public async getSupportInfo(): Promise<{
+  public async getSupportInfo({ plugins }: { plugins: string[] }): Promise<{
     languages: PrettierSupportLanguage[];
   }> {
     if (!this.prettierModule) {
       await this.import();
     }
-    return this.prettierModule!.getSupportInfo();
+    // @ts-expect-error actually getSupportInfo can recieve option
+    return this.prettierModule!.getSupportInfo({ plugins });
   }
 
   public async clearConfigCache(): Promise<void> {

--- a/src/PrettierMainThreadInstance.ts
+++ b/src/PrettierMainThreadInstance.ts
@@ -1,9 +1,13 @@
-import { FileInfoOptions, Options } from "prettier";
+import { FileInfoOptions, Options, ResolveConfigOptions } from "prettier";
 import {
   PrettierInstance,
   PrettierInstanceConstructor,
 } from "./PrettierInstance";
-import { PrettierFileInfoResult, PrettierSupportLanguage } from "./types";
+import {
+  PrettierFileInfoResult,
+  PrettierPlugin,
+  PrettierSupportLanguage,
+} from "./types";
 import { PrettierNodeModule } from "./ModuleResolver";
 import { loadNodeModule } from "./ModuleLoader";
 
@@ -44,7 +48,11 @@ export const PrettierMainThreadInstance: PrettierInstanceConstructor = class Pre
     return this.prettierModule!.getFileInfo(filePath, fileInfoOptions);
   }
 
-  public async getSupportInfo({ plugins }: { plugins: string[] }): Promise<{
+  public async getSupportInfo({
+    plugins,
+  }: {
+    plugins: (string | PrettierPlugin)[];
+  }): Promise<{
     languages: PrettierSupportLanguage[];
   }> {
     if (!this.prettierModule) {
@@ -59,5 +67,24 @@ export const PrettierMainThreadInstance: PrettierInstanceConstructor = class Pre
       await this.import();
     }
     return this.prettierModule!.clearConfigCache();
+  }
+
+  public async resolveConfigFile(
+    filePath?: string | undefined
+  ): Promise<string | null> {
+    if (!this.prettierModule) {
+      await this.import();
+    }
+    return this.prettierModule!.resolveConfigFile(filePath);
+  }
+
+  public async resolveConfig(
+    fileName: string,
+    options?: ResolveConfigOptions | undefined
+  ): Promise<Options | null> {
+    if (!this.prettierModule) {
+      await this.import();
+    }
+    return this.prettierModule!.resolveConfig(fileName, options);
   }
 };

--- a/src/PrettierWorkerInstance.ts
+++ b/src/PrettierWorkerInstance.ts
@@ -79,10 +79,10 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
     return result;
   }
 
-  public async getSupportInfo(): Promise<{
+  public async getSupportInfo({ plugins }: { plugins: string[] }): Promise<{
     languages: PrettierSupportLanguage[];
   }> {
-    const result = await this.callMethod("getSupportInfo", []);
+    const result = await this.callMethod("getSupportInfo", [{ plugins }]);
     return result;
   }
 

--- a/src/PrettierWorkerInstance.ts
+++ b/src/PrettierWorkerInstance.ts
@@ -5,12 +5,14 @@ import {
   PrettierFileInfoOptions,
   PrettierFileInfoResult,
   PrettierOptions,
+  PrettierPlugin,
   PrettierSupportLanguage,
 } from "./types";
 import {
   PrettierInstance,
   PrettierInstanceConstructor,
 } from "./PrettierInstance";
+import { ResolveConfigOptions, Options } from "prettier";
 
 const worker = new Worker(
   url.pathToFileURL(path.join(__dirname, "/worker/prettier-instance-worker.js"))
@@ -79,7 +81,11 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
     return result;
   }
 
-  public async getSupportInfo({ plugins }: { plugins: string[] }): Promise<{
+  public async getSupportInfo({
+    plugins,
+  }: {
+    plugins: (string | PrettierPlugin)[];
+  }): Promise<{
     languages: PrettierSupportLanguage[];
   }> {
     const result = await this.callMethod("getSupportInfo", [{ plugins }]);
@@ -98,6 +104,21 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
       filePath,
       fileInfoOptions,
     ]);
+    return result;
+  }
+
+  public async resolveConfigFile(
+    filePath?: string | undefined
+  ): Promise<string | null> {
+    const result = await this.callMethod("resolveConfigFile", [filePath]);
+    return result;
+  }
+
+  public async resolveConfig(
+    fileName: string,
+    options?: ResolveConfigOptions | undefined
+  ): Promise<Options> {
+    const result = await this.callMethod("resolveConfig", [fileName, options]);
     return result;
   }
 

--- a/src/test/suite/v3-plugins.test.ts
+++ b/src/test/suite/v3-plugins.test.ts
@@ -1,0 +1,15 @@
+import * as assert from "assert";
+import { format, getText } from "./format.test";
+
+suite("Test v3 + plugins", function () {
+  this.timeout(10000);
+  test("it formats with v3 + plugins", async () => {
+    const { actual } = await format(
+      "v3-plugins",
+      "index.xml",
+      /* shouldRetry */ true
+    );
+    const expected = await getText("v3-plugins", "index.result.xml");
+    assert.equal(actual, expected);
+  });
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,5 @@
 import * as prettier from "prettier";
-import { TextDocument } from "vscode";
+import { TextDocument, Uri } from "vscode";
 import { PrettierInstance } from "./PrettierInstance";
 
 type PrettierSupportLanguage = {
@@ -40,6 +40,18 @@ type ModuleResolverInterface = {
     vscodeConfig: PrettierVSCodeConfig
   ): Promise<"error" | "disabled" | PrettierOptions | null>;
   dispose(): void;
+  resolveConfig(
+    prettierInstance: {
+      resolveConfigFile(filePath?: string): Promise<string | null>;
+      resolveConfig(
+        fileName: string,
+        options?: prettier.ResolveConfigOptions
+      ): Promise<PrettierOptions | null>;
+    },
+    uri: Uri,
+    fileName: string,
+    vscodeConfig: PrettierVSCodeConfig
+  ): Promise<"error" | "disabled" | PrettierOptions | null>;
 };
 
 type TrailingCommaOption = "none" | "es5" | "all";

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,6 +15,7 @@ type PrettierBuiltInParserName = string;
 type PrettierResolveConfigOptions = prettier.ResolveConfigOptions;
 type PrettierOptions = prettier.Options;
 type PrettierFileInfoOptions = prettier.FileInfoOptions;
+type PrettierPlugin = prettier.Plugin<any>;
 
 type PrettierModule = {
   format(source: string, options?: prettier.Options): string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import * as os from "os";
 import * as path from "path";
+import * as semver from "semver";
 import { Uri, workspace } from "vscode";
 import { PrettierVSCodeConfig } from "./types";
 
@@ -50,4 +51,12 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
   }
 
   return config;
+}
+
+export function isAboveV3(version: string | null): boolean {
+  const parsedVersion = semver.parse(version);
+  if (!parsedVersion) {
+    throw new Error("Invalid version");
+  }
+  return parsedVersion.major >= 3;
 }

--- a/test-fixtures/test.code-workspace
+++ b/test-fixtures/test.code-workspace
@@ -41,6 +41,9 @@
     },
     {
       "path": "plugin-tailwindcss"
+    },
+    {
+      "path": "v3-plugins"
     }
   ],
   "settings": {

--- a/test-fixtures/v3-plugins/.prettierrc
+++ b/test-fixtures/v3-plugins/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@prettier/plugin-xml"]
+}

--- a/test-fixtures/v3-plugins/index.result.xml
+++ b/test-fixtures/v3-plugins/index.result.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  width="200"
+  height="100"
+  viewBox="0 0 200 100"
+>
+</svg>

--- a/test-fixtures/v3-plugins/index.xml
+++ b/test-fixtures/v3-plugins/index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+width="200"
+           height="100" viewBox="0 0 200 100"
+>
+</svg>

--- a/test-fixtures/v3-plugins/package-lock.json
+++ b/test-fixtures/v3-plugins/package-lock.json
@@ -1,0 +1,108 @@
+{
+  "name": "v3-plugins",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "v3-plugins",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@prettier/plugin-xml": "3.0.0-alpha.0",
+        "prettier": "^3.0.0-alpha.12"
+      }
+    },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "3.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.0.0-alpha.0.tgz",
+      "integrity": "sha512-xb04QuUCHdZfXn9aQ4E1AteLchlZFIaEnJUUygSUcmmxzV6AHtZp2/BJ/dCcMafoRFD4SF7ZyW6GpLRbEbgDrA==",
+      "dev": true,
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11",
+        "prettier": ">=3.0.0-alpha.3"
+      }
+    },
+    "node_modules/@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "dev": true,
+      "dependencies": {
+        "chevrotain": "7.1.1"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "dev": true,
+      "dependencies": {
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0-alpha.12.tgz",
+      "integrity": "sha512-QCCLoJ+ttw/DV6zLiHJDZdC7sZ23fk3gCulQmjU6AuA/Uk8o6qbzM4afyEDIM94xhj7MEGDtKYo+ZFpxwjmSEg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@prettier/plugin-xml": {
+      "version": "3.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.0.0-alpha.0.tgz",
+      "integrity": "sha512-xb04QuUCHdZfXn9aQ4E1AteLchlZFIaEnJUUygSUcmmxzV6AHtZp2/BJ/dCcMafoRFD4SF7ZyW6GpLRbEbgDrA==",
+      "dev": true,
+      "requires": {
+        "@xml-tools/parser": "^1.0.11",
+        "prettier": ">=3.0.0-alpha.3"
+      }
+    },
+    "@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "dev": true,
+      "requires": {
+        "chevrotain": "7.1.1"
+      }
+    },
+    "chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "dev": true,
+      "requires": {
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "prettier": {
+      "version": "3.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0-alpha.12.tgz",
+      "integrity": "sha512-QCCLoJ+ttw/DV6zLiHJDZdC7sZ23fk3gCulQmjU6AuA/Uk8o6qbzM4afyEDIM94xhj7MEGDtKYo+ZFpxwjmSEg==",
+      "dev": true
+    },
+    "regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true
+    }
+  }
+}

--- a/test-fixtures/v3-plugins/package.json
+++ b/test-fixtures/v3-plugins/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "v3-plugins",
+  "version": "1.0.0",
+  "description": "Test folder for v3 + plugins",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "@prettier/plugin-xml": "3.0.0-alpha.0",
+    "prettier": "^3.0.0-alpha.12"
+  }
+}

--- a/test-fixtures/v3/.prettierrc.mjs
+++ b/test-fixtures/v3/.prettierrc.mjs
@@ -1,0 +1,3 @@
+export default {
+  tabWidth: 4,
+};

--- a/test-fixtures/v3/index.result.ts
+++ b/test-fixtures/v3/index.result.ts
@@ -1,6 +1,6 @@
 const Counter = decorator("my-counter")((props: {
-  initialCount?: number;
-  label?: string;
+    initialCount?: number;
+    label?: string;
 }) => {
-  // ...
+    // ...
 });


### PR DESCRIPTION
This PR accomplishes two things.

**First, it enables the use of plugins with the new major version, v3:**

In prettier-vscode, we first retrieve the information about supported languages using `getSupportInfo`, which is then communicated to VSCode.

Up until Prettier v2, Prettier automatically resolved plugins when executing getSupportInfo. However, in Prettier v3, the feature for automatic plugin resolution is removed.

Therefore, before running `getSupportInfo`, it is necessary to explicitly resolve the settings and obtain a list of plugins to be used.

**Second, it modifies the `getResolvedConfig` in `ModuleResolver` to use the Prettier instance that the user is using, rather than the default Prettier, to resolve the settings:**

With Prettier v3, it becomes possible to use configuration files with names that were not previously available, such as .prettierrc.mjs. Since the default Prettier version is 2.8.8, the current `ModuleResolver#getResolveConfig` cannot resolve the settings of .prettierrc.mjs.

Both of these setting resolution parts are commonized and abstracted as the `ModuleResolver#resolveConfig` method.

- [x] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
