### PR TITLE
Fix module resolution with prettierPath setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [Unreleased]
+
+- Fix module resolution with `prettierPath` setting
+
 ## [9.16.0]
 
 - Run only Prettier v3 in worker_threads. Run v2 in main thread.

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -122,7 +122,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           return pkgFilePath;
         }
       },
-      { cwd: path.dirname(modulePath) }
+      { cwd: modulePath }
     );
 
     if (!packageJsonPath) {


### PR DESCRIPTION
Fixes #3041.

#3038 attempts to find a `package.json` starting at a given `modulePath`, but starts one directory further up than it should.