### PR TITLE
feat: allow prettier to use custom `node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+- Adds `prettier.runtime` config value to allow choosing the command to run prettier
+
 ## [9.19.0]
 
 - Reverts change to `prettierPath` resolution. (#3045)

--- a/package.json
+++ b/package.json
@@ -189,6 +189,11 @@
           "markdownDescription": "%ext.config.resolveGlobalModules%",
           "scope": "resource"
         },
+        "prettier.runtime": {
+          "type": "string",
+          "markdownDescription": "%ext.config.runtime%",
+          "scope": "resource"
+        },
         "prettier.withNodeModules": {
           "type": "boolean",
           "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -27,6 +27,7 @@
   "ext.config.requireConfig": "Require a prettier configuration file to format. See [documentation for valid configuration files](https://prettier.io/docs/en/configuration.html).\n\n> _Note, untitled files will still be formatted using the VS Code prettier settings even when this setting is set._",
   "ext.config.requirePragma": "Prettier can restrict itself to only format files that contain a special comment, called a pragma, at the top of the file. This is very useful when gradually transitioning large, unformatted codebases to prettier.",
   "ext.config.resolveGlobalModules": "When enabled, this extension will attempt to use global npm or yarn modules if local modules cannot be resolved.\n> _This setting can have a negative performance impact, particularly on Windows when you have attached network drives. Only enable this if you must use global modules._",
+  "ext.config.runtime": "he location of the node binary to run prettier under.",
   "ext.config.withNodeModules": "This extension will process files in `node_modules`.",
   "ext.config.semi": "Whether to add a semicolon at the end of every line.",
   "ext.config.singleQuote": "Use single instead of double quotes.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -19,6 +19,7 @@
   "ext.config.requireConfig": "Prettier 配置文件（如 `.prettierrc`）必须存在。详见 [配置文件的文档说明](https://prettier.io/docs/en/configuration.html)。\n\n_注意：未命名文件仍会使用 `VS Code` 的 `setting.json` 中的配置进行格式化，不受该选项影响。_",
   "ext.config.requirePragma": "Prettier 可以限制只对包含特定注释的文件进行格式化，这个特定的注释称为 pragma。这对于那些大型的、尚未采用 Prettier 的代码仓库逐步引入 Prettier 非常有用。",
   "ext.config.resolveGlobalModules": "如果在当前项目中找不到 `prettier` 包时尝试使用 npm 或 yarn 全局安装的包。\n>_该设置可能影响性能，特别是在 Windows 中挂载了网络磁盘的时候。只有在你需要使用全局安装的包时再启用。_",
+  "ext.config.runtime": "TODO TRANSLATE ME",
   "ext.config.withNodeModules": "允许 Prettier 格式化 `node_modules` 中的文件。",
   "ext.config.semi": "在所有代码语句的末尾添加分号。",
   "ext.config.singleQuote": "使用单引号而不是双引号。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -24,6 +24,7 @@
   "ext.config.requireConfig": "排版需要 prettier 組態檔。參閱[可用的組態檔文件](https://prettier.io/docs/en/configuration.html).\n\n> _注意，無標題檔案仍會使用 VS Code 的 prettier 設定進行排版，不受這個設定值影響。_",
   "ext.config.requirePragma": "Prettier 可以限制它自己只對包含特殊註解的檔案進行排版，這個特殊的註解成為 pragma ，位於檔案的最頂部。這對於想要對那些大型、未經過排版的程式碼緩步採納 prettier 非常有幫助。",
   "ext.config.resolveGlobalModules": "這個套件會在區域的模組找不到 prettier 模組時嘗試使用去全域的 npm 或 yarn 模組中尋找。\n> _這個設定會導致效能的負面影響，特別在 Windows 中有掛載網路磁碟機。只有在你必須使用全域模組的情況下再啟用。_",
+  "ext.config.runtime": "TODO TRANSLATE ME",
   "ext.config.withNodeModules": "這個套件會對 node_modules 的檔案進行排版。",
   "ext.config.semi": "是否要在每一列的結尾加上分號。",
   "ext.config.singleQuote": "會使用單引號而非雙引號。",

--- a/src/ChildProcessWorker.ts
+++ b/src/ChildProcessWorker.ts
@@ -1,0 +1,105 @@
+import { fileURLToPath, URL } from "url";
+import { ChildProcess, fork, ForkOptions } from "child_process";
+import { EventEmitter } from "events";
+
+export class ChildProcessWorker {
+  #process: ChildProcess | null = null;
+  #url: URL;
+  #processOptions: ForkOptions;
+  #events: EventEmitter;
+  #queue: any[];
+
+  constructor(url: URL, processOptions: ForkOptions) {
+    this.#url = url;
+    this.#processOptions = processOptions;
+    this.#events = new EventEmitter();
+    this.#queue = [];
+    void Promise.resolve().then(() => this.startProcess());
+  }
+
+  startProcess() {
+    try {
+      const stderr: Buffer[] = [];
+      const stdout: Buffer[] = [];
+      this.#process = fork(fileURLToPath(this.#url), [], {
+        ...this.#processOptions,
+        stdio: ["pipe", "pipe", "pipe", "ipc"],
+      });
+      this.#process.stderr?.on("data", (chunk) => {
+        stderr.push(chunk);
+      });
+      this.#process.stdout?.on("data", (chunk) => {
+        stdout.push(chunk);
+      });
+      this.#process
+        .on("error", (err) => {
+          this.#process = null;
+          this.#events.emit("error", err);
+        })
+        .on("exit", (code) => {
+          this.#process = null;
+          const stdoutResult = Buffer.concat(stdout).toString("utf8");
+          const stderrResult = Buffer.concat(stderr).toString("utf8");
+          if (code !== 0) {
+            this.#events.emit(
+              "error",
+              new Error(
+                `Process crashed with code ${code}: ${stdoutResult} ${stderrResult}`
+              )
+            );
+          } else {
+            this.#events.emit(
+              "error",
+              new Error(
+                `Process unexpectedly exit:  ${stdoutResult} ${stderrResult}`
+              )
+            );
+          }
+        })
+        .on("message", (msg) => {
+          this.#events.emit("message", msg);
+        });
+      this.flushQueue();
+    } catch (err) {
+      this.#process = null;
+      this.#events.emit("error", err);
+    }
+  }
+
+  on(evt: string, fn: (payload: any) => void) {
+    if (evt === "message" || evt === "error") {
+      this.#events.on(evt, fn);
+      return;
+    }
+    throw new Error(`Unsupported event ${evt}.`);
+  }
+
+  flushQueue() {
+    if (!this.#process) {
+      return;
+    }
+    let items = 0;
+    for (const entry of this.#queue) {
+      if (!this.#process.send(entry)) {
+        break;
+      }
+      items++;
+    }
+    if (items > 0) {
+      this.#queue.splice(0, items);
+    }
+  }
+
+  postMessage(data: any) {
+    this.flushQueue();
+    if (this.#process) {
+      if (this.#process.send(data)) {
+        return true;
+      } else {
+        this.#queue.push(data);
+      }
+    }
+    this.#queue.push(data);
+    return false;
+  }
+}

--- a/src/PrettierInstance.ts
+++ b/src/PrettierInstance.ts
@@ -5,7 +5,9 @@ import {
   PrettierOptions,
   PrettierPlugin,
   PrettierSupportLanguage,
+  PrettierVSCodeConfig,
 } from "./types";
+import { LoggingService } from "./LoggingService";
 
 export interface PrettierInstance {
   version: string | null;
@@ -30,6 +32,11 @@ export interface PrettierInstance {
   ): Promise<PrettierOptions | null>;
 }
 
+export interface PrettierInstanceContext {
+  config: PrettierVSCodeConfig;
+  loggingService: LoggingService;
+}
+
 export interface PrettierInstanceConstructor {
-  new (modulePath: string): PrettierInstance;
+  new (modulePath: string, context: PrettierInstanceContext): PrettierInstance;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -102,6 +102,10 @@ interface IExtensionConfig {
    * If true, enabled debug logs
    */
   enableDebugLogs: boolean;
+  /**
+   * If defined, a path to the node runtime.
+   */
+  runtime: string | undefined;
 }
 /**
  * Configuration for prettier-vscode

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,6 +46,7 @@ export function getConfig(uri?: Uri): PrettierVSCodeConfig {
       useEditorConfig: false,
       withNodeModules: false,
       resolveGlobalModules: false,
+      runtime: undefined,
     };
     return newConfig;
   }

--- a/src/worker/prettier-instance-worker-process.js
+++ b/src/worker/prettier-instance-worker-process.js
@@ -1,0 +1,16 @@
+const createWorker = require("./prettier-instance-worker");
+
+const parentPort = {
+  on: (evt, fn) => {
+    if (evt === "message") {
+      process.on(evt, fn);
+      return;
+    }
+    throw new Error(`Unsupported event ${evt}.`);
+  },
+  postMessage(msg) {
+    process.send(msg);
+  },
+};
+
+createWorker(parentPort);

--- a/src/worker/prettier-instance-worker-thread.js
+++ b/src/worker/prettier-instance-worker-thread.js
@@ -1,0 +1,4 @@
+const { parentPort } = require("worker_threads");
+const createWorker = require("./prettier-instance-worker");
+
+createWorker(parentPort);

--- a/src/worker/prettier-instance-worker.js
+++ b/src/worker/prettier-instance-worker.js
@@ -1,5 +1,3 @@
-const { parentPort } = require("worker_threads");
-
 const path2ModuleCache = new Map();
 
 function requireInstance(modulePath) {
@@ -14,81 +12,84 @@ function requireInstance(modulePath) {
   return prettierInstance;
 }
 
-parentPort.on("message", ({ type, payload }) => {
-  switch (type) {
-    case "import": {
-      const { modulePath } = payload;
-      try {
-        const prettierInstance = requireInstance(modulePath);
-        parentPort.postMessage({
-          type,
-          payload: { version: prettierInstance.version },
-        });
-      } catch {
-        parentPort.postMessage({
-          type,
-          payload: { version: null },
-        });
-      }
-      break;
-    }
-    case "callMethod": {
-      const { modulePath, methodName, methodArgs, id } = payload;
-      const postError = (error) => {
-        parentPort.postMessage({
-          type,
-          payload: { result: error, id, isError: true },
-        });
-      };
-      let prettierInstance = path2ModuleCache.get(modulePath);
-      if (!prettierInstance) {
+function normalizeResult(methodName, id, result) {
+  // For prettier-vscode, `languages` are enough
+  if (methodName === "getSupportInfo") {
+    result = { languages: result.languages };
+  }
+  return {
+    type: "callMethod",
+    payload: { result, id, isError: false },
+  };
+}
+
+module.exports = (parentPort) => {
+  parentPort.on("message", ({ type, payload }) => {
+    switch (type) {
+      case "import": {
+        const { modulePath } = payload;
         try {
-          prettierInstance = requireInstance(modulePath);
+          const prettierInstance = requireInstance(modulePath);
+          parentPort.postMessage({
+            type,
+            payload: { version: prettierInstance.version },
+          });
+        } catch {
+          parentPort.postMessage({
+            type,
+            payload: { version: null },
+          });
+        }
+        break;
+      }
+      case "callMethod": {
+        const { modulePath, methodName, methodArgs, id } = payload;
+        const postError = (error) => {
+          parentPort.postMessage({
+            type,
+            payload: {
+              result: error && error.stack ? error.stack.toString() : error,
+              id,
+              isError: true,
+            },
+          });
+        };
+        let prettierInstance = path2ModuleCache.get(modulePath);
+        if (!prettierInstance) {
+          try {
+            prettierInstance = requireInstance(modulePath);
+          } catch (error) {
+            postError(error);
+          }
+        }
+        let result;
+        try {
+          result = prettierInstance[methodName](...methodArgs);
         } catch (error) {
           postError(error);
         }
-      }
-      let result;
-      try {
-        result = prettierInstance[methodName](...methodArgs);
-      } catch (error) {
-        postError(error);
-      }
-      if (result instanceof Promise) {
-        result.then(
-          (value) => {
-            try {
-              // For prettier-vscode, `languages` are enough
-              if (methodName === "getSupportInfo") {
-                value = { languages: value.languages };
+        if (result instanceof Promise) {
+          result.then(
+            (value) => {
+              try {
+                parentPort.postMessage(normalizeResult(methodName, id, value));
+              } catch (error) {
+                postError(error);
               }
-              parentPort.postMessage({
-                type,
-                payload: { result: value, id, isError: false },
-              });
-            } catch (error) {
-              postError(error);
+            },
+            (reason) => {
+              postError(reason);
             }
-          },
-          (reason) => {
-            postError(reason);
-          }
-        );
+          );
+          break;
+        }
+        try {
+          parentPort.postMessage(normalizeResult(methodName, id, result));
+        } catch (error) {
+          postError(error);
+        }
         break;
       }
-      try {
-        // For prettier-vscode, `languages` are enough
-        if (methodName === "getSupportInfo") {
-          result = { languages: result.languages };
-        }
-        parentPort.postMessage({
-          type,
-          payload: { result, id, isError: false },
-        });
-      } catch (error) {
-        postError(error);
-      }
-      break;
     }
-  }
-});
+  });
+};


### PR DESCRIPTION
Adds a `prettier.runtime` configuration option that, when used, invokes a version of `PrettierWorkerInstance` that uses `fork` instead of worker threads.

Maybe fixes: https://github.com/prettier/prettier-vscode/issues/3017
Fixes: https://github.com/prettier/prettier-vscode/issues/2857

TODO:
- [ ] Run tests – I have a few tests left to fix (not entirely sure why… since the new codepath should only ever be enabled when `prettier.runtime` is set…), but I'm happy for early feedback if this is something the maintainers are willing to consider before moving ahead.
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
