### PR TITLE
Clarify that ext.config.enable requires a reload.

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -37,7 +37,7 @@
   "ext.config.useTabs": "Indent lines with tabs.",
   "ext.config.vueIndentScriptAndStyle": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue SFC files.",
   "ext.config.embeddedLanguageFormatting": "Control whether Prettier formats quoted code embedded in the file.",
-  "ext.config.enable": "Controls whether Prettier is enabled or not.",
+  "ext.config.enable": "Controls whether Prettier is enabled or not. Reload required.",
   "ext.config.enableDebugLogs": "Enable debug logs for troubleshooting.",
   "ext.capabilities.untrustedWorkspaces.description": "Only the built-in version of Prettier will be used when running in untrusted mode."
 }


### PR DESCRIPTION
- [x] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes
    *(assuming this is too minor for the changelog...)*

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md

The README [notes that ext.config.enable requires a reload](https://github.com/prettier/prettier-vscode#prettierenable-default-true), but the plugin settings do not. A user may first encounter this setting in VS Code and not be aware that changing it requires a restart.

This PR brings the settings language into consistency with the README to say that a reload is required.