### PR TITLE
Support Language Overrides for printWidth in settings.JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+Support per-language printWidth configuration in VS Code preferences JSON
+
 ## [10.1.0]
 
 Reverts back to prettier 2.x by default due to issues with extension

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
           "type": "integer",
           "default": 80,
           "markdownDescription": "%ext.config.printWidth%",
-          "scope": "resource"
+          "scope": "language-overridable"
         },
         "prettier.tabWidth": {
           "type": "integer",

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -270,7 +270,7 @@ export default class PrettierEditService implements Disposable {
         prettierInstance,
         uri,
         uri.fsPath,
-        getConfig(uri)
+        getConfig(window.activeTextEditor?.document || uri)
       );
       if (resolvedConfig === "error") {
         this.statusBar.update(FormatterStatus.Error);
@@ -403,7 +403,7 @@ export default class PrettierEditService implements Disposable {
 
     this.loggingService.logInfo(`Formatting ${uri}`);
 
-    const vscodeConfig = getConfig(uri);
+    const vscodeConfig = getConfig(doc);
 
     const resolvedConfig = await this.moduleResolver.getResolvedConfig(
       doc,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
-import { Uri, workspace } from "vscode";
+import { TextDocument, Uri, workspace } from "vscode";
 import { PrettierVSCodeConfig } from "./types";
 
 export function getWorkspaceRelativePath(
@@ -27,11 +27,11 @@ export function getWorkspaceRelativePath(
   }
 }
 
-export function getConfig(uri?: Uri): PrettierVSCodeConfig {
+export function getConfig(scope?: Uri | TextDocument): PrettierVSCodeConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const config = workspace.getConfiguration(
     "prettier",
-    uri
+    scope
   ) as unknown as PrettierVSCodeConfig;
 
   // Some settings are disabled for untrusted workspaces


### PR DESCRIPTION
Closes #3093. Adds support for language overrides for the prettier.printWidth configuration option in settings.json.

- Updated the extension manifest to specify the `language-overridable` scope on `prettier.printWidth`
- Updated `getConfig()` to respect language-specific settings by accepting `activeTextEditor.document` as the scope parameter. (`workspace.getConfiguration()` ignores language overrides when a URI is passed as the scope.)
- Updated PrettierEditService to pass the `activeTextEditor.document` as the scope parameter if available and fallback to URI.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`] with a summary of your changes