### PR TITLE
fix: misrecognizing path in vscode due to added quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+Fixed the issue where VSCode was misrecognizing the path in output panel due to added quotes.
+
 ## [10.1.0]
 
 Reverts back to prettier 2.x by default due to issues with extension

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -216,7 +216,7 @@ export class ModuleResolver implements ModuleResolverInterface {
 
     if (modulePath !== undefined) {
       this.loggingService.logDebug(
-        `Local prettier module path: '${modulePath}'`
+        `Local prettier module path: ${modulePath}`
       );
       // First check module cache
       moduleInstance = this.path2Module.get(modulePath);
@@ -377,7 +377,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     }
     if (resolveConfigOptions.config) {
       this.loggingService.logInfo(
-        `Using config file at '${resolveConfigOptions.config}'`
+        `Using config file at ${resolveConfigOptions.config}`
       );
     }
 

--- a/src/TemplateService.ts
+++ b/src/TemplateService.ts
@@ -25,7 +25,7 @@ export class TemplateService {
       formatterOptions
     );
 
-    this.loggingService.logInfo(`Writing .prettierrc to '${outputPath}'`);
+    this.loggingService.logInfo(`Writing .prettierrc to ${outputPath}`);
     await workspace.fs.writeFile(
       outputPath,
       new TextEncoder().encode(templateSource)


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

VSCode will recognize the quotes as a part of the path(`.prettierrc.js'` instead of `.prettierrc.js`), thus, it causes an error when I use `cmd + click` to open a file path.
<img width="260" alt="image" src="https://github.com/prettier/prettier-vscode/assets/48613687/e3404b8d-426a-433f-a45f-5b41f770f090">
<img width="1617" alt="image" src="https://github.com/prettier/prettier-vscode/assets/48613687/42fe0494-9e55-4bb7-a716-161889658456">

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
