### PR TITLE
Update config resolution for Prettier 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
-Fixed the issue where VSCode was misrecognizing the path in output panel due to added quotes.
+- Fixed the issue where VSCode was misrecognizing the path in output panel due to added quotes.
+- Fixed config resolution that caused plugins to be ignored when using Prettier 3.1.1 or later. (#3252)
 
 ## [10.1.0]
 


### PR DESCRIPTION
Fixes #3253.

- [ ] No tests broken
- [x] `CHANGELOG.md` updated
- [ ] Code is formatted

Currently makes 1 one more test fail ("Test configurations": "it formats custom file extension") and I'll try to investigate why, but I wanted to at least post this for discussion.

The change is to resolve config for the active file not for the workspace directory. Passing the root directory to resolveConfig was broken in Prettier v3.1.1 with no intention of reverting, as reported here: https://github.com/prettier/prettier/issues/15879