### PR TITLE
Fix module resolution with `prettierPath` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
-Fixed the issue where VSCode was misrecognizing the path in output panel due to added quotes.
+- Fixed the issue where VSCode was misrecognizing the path in output panel due to added quotes.
+- Fix module resolution with `prettierPath` setting
 
 ## [10.1.0]
 

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -114,7 +114,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           return pkgFilePath;
         }
       },
-      { cwd: path.dirname(modulePath) }
+      { cwd: modulePath }
     );
 
     if (!packageJsonPath) {
@@ -356,8 +356,8 @@ export class ModuleResolver implements ModuleResolverInterface {
       config: isVirtual
         ? undefined
         : vscodeConfig.configPath
-        ? getWorkspaceRelativePath(fileName, vscodeConfig.configPath)
-        : configPath,
+          ? getWorkspaceRelativePath(fileName, vscodeConfig.configPath)
+          : configPath,
       editorconfig: isVirtual ? undefined : vscodeConfig.useEditorConfig,
     };
 

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -179,7 +179,8 @@ export class ModuleResolver implements ModuleResolverInterface {
       }
 
       this.loggingService.logInfo(
-        `Attempted to determine module path from ${modulePath || moduleDirectory || "package.json"
+        `Attempted to determine module path from ${
+          modulePath || moduleDirectory || "package.json"
         }`
       );
       this.loggingService.logError(FAILED_TO_LOAD_MODULE_MESSAGE, error);
@@ -238,7 +239,8 @@ export class ModuleResolver implements ModuleResolverInterface {
           }
         } catch (error) {
           this.loggingService.logInfo(
-            `Attempted to load Prettier module from ${modulePath || "package.json"
+            `Attempted to load Prettier module from ${
+              modulePath || "package.json"
             }`
           );
           this.loggingService.logError(FAILED_TO_LOAD_MODULE_MESSAGE, error);

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -179,8 +179,7 @@ export class ModuleResolver implements ModuleResolverInterface {
       }
 
       this.loggingService.logInfo(
-        `Attempted to determine module path from ${
-          modulePath || moduleDirectory || "package.json"
+        `Attempted to determine module path from ${modulePath || moduleDirectory || "package.json"
         }`
       );
       this.loggingService.logError(FAILED_TO_LOAD_MODULE_MESSAGE, error);
@@ -239,8 +238,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           }
         } catch (error) {
           this.loggingService.logInfo(
-            `Attempted to load Prettier module from ${
-              modulePath || "package.json"
+            `Attempted to load Prettier module from ${modulePath || "package.json"
             }`
           );
           this.loggingService.logError(FAILED_TO_LOAD_MODULE_MESSAGE, error);
@@ -356,8 +354,8 @@ export class ModuleResolver implements ModuleResolverInterface {
       config: isVirtual
         ? undefined
         : vscodeConfig.configPath
-          ? getWorkspaceRelativePath(fileName, vscodeConfig.configPath)
-          : configPath,
+        ? getWorkspaceRelativePath(fileName, vscodeConfig.configPath)
+        : configPath,
       editorconfig: isVirtual ? undefined : vscodeConfig.useEditorConfig,
     };
 


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

This fix was once proposed in https://github.com/prettier/prettier-vscode/commit/d04b294a15f9dc20e1dc061013b57c7aa8f2764c, but was reverted in https://github.com/prettier/prettier-vscode/commit/f6ff18b500858b913ef43dbad73ecbae929c.

However, this is actually a misunderstanding. Let me analyze the entire process of the matter.
1. #3041 This bug was first raised. The version of Prettier in the issue is 9.16.0
2. #3042 This bug was subsequently fixed, and the fix was first released in version 9.17.0
3. #3045 raised this bug again. The version of Prettier in the issue is also 9.16.0. However, at this time @ntotten [mistakenly thought that this was caused by the change](https://github.com/prettier/prettier-vscode/issues/3045#issuecomment-1614745069) https://github.com/prettier/prettier-vscode/commit/d04b294a15f9dc20e1dc061013b57c7aa8f2764c, but this is obviously impossible, because https://github.com/prettier/prettier-vscode/commit/d04b294a15f9dc20e1dc061013b57c7aa8f2764c did not appear in the release version until 9.17.0. (I don’t mean to blame ntotten)
4. At the same time, we can see in #3045 and #3041 that after the issue was closed, [most people reported that the bug had not been fixed](https://github.com/prettier/prettier-vscode/issues/3045#issuecomment-1614994507), which further illustrates what was reverted in https://github.com/prettier/prettier-vscode/commit/f6ff18b500858b913ef43dbad73ecbae929c3b27 is wrong.

Therefore, I am re-fixing this long-standing bug today. 🥰


[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
