### PR TITLE
Fix worker call IDs with multiple worker instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+- Fix issue where formatting multiple files in a workspace with multiple instances of Prettier could result in files being overwritten with the contents of other files (#3423, #3040)
+
 ## [10.5.0]
 
 - Extend list of Prettier config files by ECMAScript module extentions

--- a/src/PrettierWorkerInstance.ts
+++ b/src/PrettierWorkerInstance.ts
@@ -14,6 +14,8 @@ import {
   PrettierSupportLanguage,
 } from "./types";
 
+let currentCallMethodId = 0;
+
 const worker = new Worker(
   url.pathToFileURL(path.join(__dirname, "/worker/prettier-instance-worker.js"))
 );
@@ -33,8 +35,6 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
       reject: (value: unknown) => void;
     }
   > = new Map();
-
-  private currentCallMethodId = 0;
 
   public version: string | null = null;
 
@@ -124,7 +124,7 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private callMethod(methodName: string, methodArgs: unknown[]): Promise<any> {
-    const callMethodId = this.currentCallMethodId++;
+    const callMethodId = currentCallMethodId++;
     const promise = new Promise((resolve, reject) => {
       this.callMethodResolvers.set(callMethodId, { resolve, reject });
     });

--- a/src/PrettierWorkerInstance.ts
+++ b/src/PrettierWorkerInstance.ts
@@ -14,7 +14,7 @@ import {
   PrettierSupportLanguage,
 } from "./types";
 
-let currentCallMethodId = 0;
+let currentCallId = 0;
 
 const worker = new Worker(
   url.pathToFileURL(path.join(__dirname, "/worker/prettier-instance-worker.js"))
@@ -23,12 +23,7 @@ const worker = new Worker(
 export const PrettierWorkerInstance: PrettierInstanceConstructor = class PrettierWorkerInstance
   implements PrettierInstance
 {
-  private importResolver: {
-    resolve: (version: string) => void;
-    reject: (version: string) => void;
-  } | null = null;
-
-  private callMethodResolvers: Map<
+  private messageResolvers: Map<
     number,
     {
       resolve: (value: unknown) => void;
@@ -39,38 +34,40 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
   public version: string | null = null;
 
   constructor(private modulePath: string) {
-    worker.on("message", ({ type, payload }) => {
-      switch (type) {
-        case "import": {
-          this.importResolver?.resolve(payload.version);
-          this.version = payload.version;
-          break;
-        }
-        case "callMethod": {
-          const resolver = this.callMethodResolvers.get(payload.id);
-          this.callMethodResolvers.delete(payload.id);
-          if (resolver) {
+    worker.on("message", ({ type, id, payload }) => {
+      const resolver = this.messageResolvers.get(id);
+      if (resolver) {
+        this.messageResolvers.delete(id);
+        switch (type) {
+          case "import": {
+            resolver.resolve(payload.version);
+            this.version = payload.version;
+            break;
+          }
+          case "callMethod": {
             if (payload.isError) {
               resolver.reject(payload.result);
             } else {
               resolver.resolve(payload.result);
             }
+            break;
           }
-          break;
         }
       }
     });
   }
 
   public async import(): Promise</* version of imported prettier */ string> {
-    const promise = new Promise<string>((resolve, reject) => {
-      this.importResolver = { resolve, reject };
+    const callId = currentCallId++;
+    const promise = new Promise((resolve, reject) => {
+      this.messageResolvers.set(callId, { resolve, reject });
     });
     worker.postMessage({
       type: "import",
+      id: callId,
       payload: { modulePath: this.modulePath },
     });
-    return promise;
+    return promise as Promise<string>;
   }
 
   public async format(
@@ -124,14 +121,14 @@ export const PrettierWorkerInstance: PrettierInstanceConstructor = class Prettie
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private callMethod(methodName: string, methodArgs: unknown[]): Promise<any> {
-    const callMethodId = currentCallMethodId++;
+    const callId = currentCallId++;
     const promise = new Promise((resolve, reject) => {
-      this.callMethodResolvers.set(callMethodId, { resolve, reject });
+      this.messageResolvers.set(callId, { resolve, reject });
     });
     worker.postMessage({
       type: "callMethod",
+      id: callId,
       payload: {
-        id: callMethodId,
         modulePath: this.modulePath,
         methodName,
         methodArgs,


### PR DESCRIPTION
Fixes #3423, #3040 

Previously, `currentCallMethodId` was a field on each instance of PrettierWorkerInstance, however, there is only a single instance of `worker`. So when multiple instances of PrettierWorkerInstance sent messages to the worker, they would each use their own `currentCallMethodId`, resulting in multiple messages with the same ID. This meant that the instances could not reliably get results back from the worker, as there were multiple results with the same ID. This caused many issues, such as overwriting files with the contents of other files while formatting.

Additionally, the "import" messages to the worker did not use IDs at all, so a PrettierWorkerInstance could end up setting the wrong version number.

This PR changes the call IDs to use a variable outside PrettierWorkerInstance, so that all instances will use the same value and cannot have overlapping IDs. It also ensures that all messages to and from the worker include an ID, so that the PrettierWorkerInstances can properly determine who a message is for.

- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
