### PR TITLE
Added support for experimentalTernaries option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
-- Prevent `.editorconfig` from satisfying the `requireConfig` setting
+- [BREAKING CHANGE] Prevent `.editorconfig` from satisfying the `requireConfig` setting
 - Fix issue where formatting multiple files in a workspace with multiple instances of Prettier could result in files being overwritten with the contents of other files (#3423, #3040)
+- Add support for `experimentalTernaries` option
 
 ## [10.5.0]
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ prettier.trailingComma
 prettier.useTabs
 prettier.vueIndentScriptAndStyle
 prettier.embeddedLanguageFormatting
+prettier.experimentalTernaries
 ```
 
 ### Extension Settings

--- a/package.json
+++ b/package.json
@@ -389,6 +389,12 @@
           "default": "auto",
           "markdownDescription": "%ext.config.embeddedLanguageFormatting%",
           "scope": "language-overridable"
+        },
+        "prettier.experimentalTernaries": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%ext.config.experimentalTernaries%",
+          "scope": "language-overridable"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -39,5 +39,6 @@
   "ext.config.embeddedLanguageFormatting": "Control whether Prettier formats quoted code embedded in the file.",
   "ext.config.enable": "Controls whether Prettier is enabled or not. Reload required.",
   "ext.config.enableDebugLogs": "Enable debug logs for troubleshooting.",
+  "ext.config.experimentalTernaries": "Try prettier's [new ternary formatting](https://github.com/prettier/prettier/pull/13183) before it becomes the default behavior.",
   "ext.capabilities.untrustedWorkspaces.description": "Only the built-in version of Prettier will be used when running in untrusted mode."
 }

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -14,6 +14,7 @@ import { getParserFromLanguageId } from "./languageFilters";
 import { LoggingService } from "./LoggingService";
 import { RESTART_TO_ENABLE } from "./message";
 import { PrettierEditProvider } from "./PrettierEditProvider";
+import { PrettierInstance } from "./PrettierInstance";
 import { FormatterStatus, StatusBar } from "./StatusBar";
 import {
   ExtensionFormattingOptions,
@@ -26,7 +27,6 @@ import {
   RangeFormattingOptions,
 } from "./types";
 import { getConfig, isAboveV3 } from "./util";
-import { PrettierInstance } from "./PrettierInstance";
 
 interface ISelectors {
   rangeLanguageSelector: ReadonlyArray<DocumentFilter>;
@@ -551,6 +551,7 @@ export default class PrettierEditService implements Disposable {
       vsOpts.embeddedLanguageFormatting =
         vsCodeConfig.embeddedLanguageFormatting;
       vsOpts.vueIndentScriptAndStyle = vsCodeConfig.vueIndentScriptAndStyle;
+      vsOpts.experimentalTernaries = vsCodeConfig.experimentalTernaries;
     }
 
     this.loggingService.logInfo(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@ type PrettierFileInfoResult = {
 };
 type PrettierBuiltInParserName = string;
 type PrettierResolveConfigOptions = prettier.ResolveConfigOptions;
-type PrettierOptions = prettier.Options;
+type PrettierOptions = prettier.Options & { experimentalTernaries?: boolean };
 type PrettierFileInfoOptions = prettier.FileInfoOptions;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PrettierPlugin = prettier.Plugin<any>;


### PR DESCRIPTION
- [ ] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
