### PR TITLE
Configure ESLint to ignore unused args prefixed with _

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,12 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": 0,
     "@typescript-eslint/no-non-null-assertion": 0,
     "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+      },
+    ],
   },
   ignorePatterns: ["test-fixtures/**"],
   parserOptions: {

--- a/src/BrowserModuleResolver.ts
+++ b/src/BrowserModuleResolver.ts
@@ -47,7 +47,6 @@ export class ModuleResolver implements ModuleResolverInterface {
   constructor(private loggingService: LoggingService) {}
 
   public async getPrettierInstance(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _fileName: string
   ): Promise<PrettierModule | undefined> {
     return this.getGlobalPrettierInstance();
@@ -164,10 +163,8 @@ export class ModuleResolver implements ModuleResolverInterface {
         };
       },
       getFileInfo: async (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        filePath: string,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        options?: PrettierFileInfoOptions
+        _filePath: string,
+        _options?: PrettierFileInfoOptions
       ): Promise<PrettierFileInfoResult> => {
         // TODO: implement ignore file reading
         return { ignored: false, inferredParser: null };
@@ -176,28 +173,22 @@ export class ModuleResolver implements ModuleResolverInterface {
   }
 
   async resolveConfig(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    prettierInstance: {
+    _prettierInstance: {
       resolveConfigFile(filePath?: string | undefined): Promise<string | null>;
       resolveConfig(
         fileName: string,
         options?: ResolveConfigOptions | undefined
       ): Promise<Options | null>;
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    uri: Uri,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    fileName: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    vscodeConfig: PrettierVSCodeConfig
+    _uri: Uri,
+    _fileName: string,
+    _vscodeConfig: PrettierVSCodeConfig
   ): Promise<Options | "error" | "disabled" | null> {
     return null;
   }
 
   async getResolvedConfig(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _doc: TextDocument,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _vscodeConfig: PrettierVSCodeConfig
   ): Promise<"error" | "disabled" | PrettierOptions | null> {
     return null;

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -36,7 +36,7 @@ export type PrettierNodeModule = typeof prettier;
 const origFsStatSync = fs.statSync;
 const fsStatSyncWorkaround = (
   path: fs.PathLike,
-  options: fs.StatSyncOptions,
+  options: fs.StatSyncOptions
 ) => {
   if (
     options?.throwIfNoEntry === true ||
@@ -155,7 +155,7 @@ export class ModuleResolver implements ModuleResolverInterface {
    * @param fileName The path of the file to use as the starting point. If none provided, the bundled prettier will be used.
    */
   public async getPrettierInstance(
-    fileName: string,
+    fileName: string
   ): Promise<PrettierNodeModule | PrettierInstance | undefined> {
     if (!workspace.isTrusted) {
       this.loggingService.logDebug(UNTRUSTED_WORKSPACE_USING_BUNDLED_PRETTIER);
@@ -163,7 +163,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     }
 
     const { prettierPath, resolveGlobalModules } = getConfig(
-      Uri.file(fileName),
+      Uri.file(fileName)
     );
 
     // Look for local module
@@ -188,7 +188,7 @@ export class ModuleResolver implements ModuleResolverInterface {
       this.loggingService.logInfo(
         `Attempted to determine module path from ${
           modulePath || moduleDirectory || "package.json"
-        }`,
+        }`
       );
       this.loggingService.logError(FAILED_TO_LOAD_MODULE_MESSAGE, error);
 
@@ -211,7 +211,7 @@ export class ModuleResolver implements ModuleResolverInterface {
       if (resolvedGlobalPackageManagerPath) {
         const globalModulePath = path.join(
           resolvedGlobalPackageManagerPath,
-          "prettier",
+          "prettier"
         );
         if (fs.existsSync(globalModulePath)) {
           modulePath = globalModulePath;
@@ -246,7 +246,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           this.loggingService.logInfo(
             `Attempted to load Prettier module from ${
               modulePath || "package.json"
-            }`,
+            }`
           );
           this.loggingService.logError(FAILED_TO_LOAD_MODULE_MESSAGE, error);
 
@@ -268,7 +268,7 @@ export class ModuleResolver implements ModuleResolverInterface {
 
       if (!isValidVersion) {
         this.loggingService.logInfo(
-          `Attempted to load Prettier module from ${modulePath}`,
+          `Attempted to load Prettier module from ${modulePath}`
         );
         this.loggingService.logError(OUTDATED_PRETTIER_VERSION_MESSAGE);
         return undefined;
@@ -284,7 +284,7 @@ export class ModuleResolver implements ModuleResolverInterface {
 
   public async getResolvedIgnorePath(
     fileName: string,
-    ignorePath: string,
+    ignorePath: string
   ): Promise<string | undefined> {
     const cacheKey = `${fileName}:${ignorePath}`;
     // cache resolvedIgnorePath because resolving it checks the file system
@@ -314,7 +314,7 @@ export class ModuleResolver implements ModuleResolverInterface {
             // https://stackoverflow.com/questions/17699599/node-js-check-if-file-exists#comment121041700_57708635
             await fs.promises.stat(p).then(
               () => true,
-              () => false,
+              () => false
             )
           ) {
             resolvedIgnorePath = p;
@@ -331,7 +331,7 @@ export class ModuleResolver implements ModuleResolverInterface {
 
   private adjustFileNameForPrettierVersion3_1_1(
     prettierInstance: { version: string | null },
-    fileName: string,
+    fileName: string
   ) {
     if (!prettierInstance.version) {
       return fileName;
@@ -350,12 +350,12 @@ export class ModuleResolver implements ModuleResolverInterface {
       resolveConfigFile(filePath?: string): Promise<string | null>;
       resolveConfig(
         fileName: string,
-        options?: prettier.ResolveConfigOptions,
+        options?: prettier.ResolveConfigOptions
       ): Promise<PrettierOptions | null>;
     },
     uri: Uri,
     fileName: string,
-    vscodeConfig: PrettierVSCodeConfig,
+    vscodeConfig: PrettierVSCodeConfig
   ): Promise<"error" | "disabled" | PrettierOptions | null> {
     const isVirtual = uri.scheme !== "file" && uri.scheme !== "vscode-userdata";
 
@@ -366,14 +366,14 @@ export class ModuleResolver implements ModuleResolverInterface {
           (await prettierInstance.resolveConfigFile(
             this.adjustFileNameForPrettierVersion3_1_1(
               prettierInstance,
-              fileName,
-            ),
+              fileName
+            )
           )) ?? undefined;
       }
     } catch (error) {
       this.loggingService.logError(
         `Error resolving prettier configuration for ${fileName}`,
-        error,
+        error
       );
       return "error";
     }
@@ -395,7 +395,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     } catch (error) {
       this.loggingService.logError(
         "Invalid prettier configuration file detected.",
-        error,
+        error
       );
       this.loggingService.logError(INVALID_PRETTIER_CONFIG);
 
@@ -403,7 +403,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     }
     if (resolveConfigOptions.config) {
       this.loggingService.logInfo(
-        `Using config file at ${resolveConfigOptions.config}`,
+        `Using config file at ${resolveConfigOptions.config}`
       );
     }
 
@@ -418,7 +418,7 @@ export class ModuleResolver implements ModuleResolverInterface {
       vscodeConfig.requireConfig
     ) {
       this.loggingService.logInfo(
-        "Require config set to true and no config present. Skipping file.",
+        "Require config set to true and no config present. Skipping file."
       );
       return "disabled";
     }
@@ -428,7 +428,7 @@ export class ModuleResolver implements ModuleResolverInterface {
 
   public async getResolvedConfig(
     { fileName, uri }: TextDocument,
-    vscodeConfig: PrettierVSCodeConfig,
+    vscodeConfig: PrettierVSCodeConfig
   ): Promise<"error" | "disabled" | PrettierOptions | null> {
     const prettierInstance: typeof prettier | PrettierInstance =
       (await this.getPrettierInstance(fileName)) || prettier;
@@ -437,7 +437,7 @@ export class ModuleResolver implements ModuleResolverInterface {
       prettierInstance,
       uri,
       fileName,
-      vscodeConfig,
+      vscodeConfig
     );
 
     return resolvedConfig;
@@ -447,7 +447,7 @@ export class ModuleResolver implements ModuleResolverInterface {
    * Clears the module and config cache
    */
   public async dispose() {
-    await prettier.clearConfigCache();
+    prettier.clearConfigCache();
     this.path2Module.forEach((module) => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -500,7 +500,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           let packageJson;
           try {
             packageJson = JSON.parse(
-              fs.readFileSync(path.join(dir, "package.json"), "utf8"),
+              fs.readFileSync(path.join(dir, "package.json"), "utf8")
             );
           } catch (e) {
             // Swallow, if we can't read it we don't want to resolve based on it
@@ -520,7 +520,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           return findUp.stop;
         }
       },
-      { cwd: finalPath, type: "directory" },
+      { cwd: finalPath, type: "directory" }
     );
 
     if (packageJsonResDir) {
@@ -540,7 +540,7 @@ export class ModuleResolver implements ModuleResolverInterface {
           return findUp.stop;
         }
       },
-      { cwd: finalPath, type: "directory" },
+      { cwd: finalPath, type: "directory" }
     );
 
     if (nodeModulesResDir) {

--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -450,8 +450,7 @@ export class ModuleResolver implements ModuleResolverInterface {
     prettier.clearConfigCache();
     this.path2Module.forEach((module) => {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        module.clearConfigCache();
+        void module.clearConfigCache();
       } catch (error) {
         this.loggingService.logError("Error clearing module cache.", error);
       }

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -24,10 +24,8 @@ export class PrettierEditProvider
   public async provideDocumentRangeFormattingEdits(
     document: TextDocument,
     range: Range,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    options: FormattingOptions,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    token: CancellationToken
+    _options: FormattingOptions,
+    _token: CancellationToken
   ): Promise<TextEdit[]> {
     return this.provideEdits(document, {
       rangeEnd: document.offsetAt(range.end),
@@ -38,10 +36,8 @@ export class PrettierEditProvider
 
   public async provideDocumentFormattingEdits(
     document: TextDocument,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    options: FormattingOptions,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    token: CancellationToken
+    _options: FormattingOptions,
+    _token: CancellationToken
   ): Promise<TextEdit[]> {
     return this.provideEdits(document, {
       force: false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,7 +28,6 @@ export function getWorkspaceRelativePath(
 }
 
 export function getConfig(scope?: TextDocument | Uri): PrettierVSCodeConfig {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const config = workspace.getConfiguration(
     "prettier",
     scope


### PR DESCRIPTION
- [x] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes _(I don't think these changes deserve to be part of the public CHANGELOG but let me know if you think otherwise @ntotten)

As the title of this PR advertises, I've configure the `no-unused-vars` linting rule to ignore variables whose name is prefixed by an underscore to avoid having a bunch of disable comments.

I also fixed a couple more of linting errors, refer to the commit history for those one-time fixes.

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md