### PR TITLE
Support resolving paths starting with `~` under Unix and Windows

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -8,9 +8,8 @@ export function getWorkspaceRelativePath(
   filePath: string,
   pathToResolve: string
 ) {
-  // In case the user wants to use ~/.prettierrc on Mac
+  // In case the user wants to use path like `~/.prettierrc` on unix or `~\.prettierrc` on windows
   if (
-    process.platform === "darwin" &&
     pathToResolve.indexOf("~") === 0 &&
     os.homedir()
   ) {


### PR DESCRIPTION
- [ ] Run tests
- [ ] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md
