### PR TITLE
Add tilde expansion to paths on Linux platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+- Add tilde expansion to paths on Linux platforms
+
 ## [12.4.0]
 
 - **Security**: Fixed config resolution in untrusted workspaces to prevent JavaScript config files (`.prettierrc.js`, `prettier.config.js`, etc.) from being executed. Previously, even when workspace trust was enforced for module resolution, Prettier's config resolution could still `require()`/`import()` JS config files, allowing arbitrary code execution. Reported by Hector Ruiz Ruiz.

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -7,9 +7,9 @@ export function getWorkspaceRelativePath(
   filePath: string,
   pathToResolve: string,
 ) {
-  // In case the user wants to use ~/.prettierrc on Mac
+  // In case the user wants to use ~/.prettierrc on Mac or Linux
   if (
-    process.platform === "darwin" &&
+    (process.platform === "darwin" || process.platform === "linux") &&
     pathToResolve.indexOf("~") === 0 &&
     os.homedir()
   ) {


### PR DESCRIPTION
- [x] Run tests
- [x] Update the [`CHANGELOG.md`][1] with a summary of your changes

[1]: https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md

Currently, tilde expansion (where paths expand `~` to a user's home directory) works for macOS but not Linux. This change adds that functionality to Linux platforms.