### PR TITLE
Bump prettier version to 3.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.0.6",
       "license": "MIT",
       "dependencies": {
-        "prettier": "3.7.1",
+        "prettier": "3.7.3",
         "semver": "7.7.3",
         "vscode-nls": "5.2.0"
       },
@@ -8162,9 +8162,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.1.tgz",
-      "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "util": "^0.12.4"
   },
   "dependencies": {
-    "prettier": "3.7.1",
+    "prettier": "3.7.3",
     "semver": "7.7.3",
     "vscode-nls": "5.2.0"
   },


### PR DESCRIPTION
## Description

Bumps bundled Prettier to 3.7.3

## Related Issue

<!-- Link to the issue this PR addresses, e.g., "Fixes #123" -->

Fixes #3848

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prettier/prettier-vscode/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project (`npm run lint` passes)
- [x] I have run `npm run prettier` to format my code
- [x] I have added/updated tests that prove my fix or feature works
- [x] All new and existing tests pass (`npm test`)
- [ ] I have updated the [CHANGELOG.md](https://github.com/prettier/prettier-vscode/blob/main/CHANGELOG.md) with a summary of my changes
