### PR TITLE
Watch .prettierignore for cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+- Watch `.prettierignore` for changes to invalidate cache (#3942)
+
 ## [12.2.0]
 
 - Fixed `source.fixAll.prettier` code action running even when `editor.defaultFormatter` was set to a different extension (#3908). The code action now respects the user's formatter choice and only runs when Prettier is the default formatter or when `source.fixAll.prettier` is explicitly enabled.

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -159,6 +159,13 @@ export default class PrettierEditService implements Disposable {
       watcher.onDidDelete(this.prettierConfigChanged);
     }
 
+    // Watch .prettierignore for changes to invalidate ignore cache
+    const prettierIgnoreWatcher =
+      workspace.createFileSystemWatcher("**/.prettierignore");
+    prettierIgnoreWatcher.onDidChange(this.prettierConfigChanged);
+    prettierIgnoreWatcher.onDidCreate(this.prettierConfigChanged);
+    prettierIgnoreWatcher.onDidDelete(this.prettierConfigChanged);
+
     const textEditorChange = window.onDidChangeActiveTextEditor(
       this.handleActiveTextEditorChangedSync,
     );
@@ -169,6 +176,7 @@ export default class PrettierEditService implements Disposable {
       packageWatcher,
       configurationWatcher,
       ...prettierConfigWatchers,
+      prettierIgnoreWatcher,
       textEditorChange,
     ];
   }


### PR DESCRIPTION
## Summary
- Added a file system watcher for `.prettierignore` files that triggers cache invalidation when the file changes, is created, or is deleted
- Uses the same `prettierConfigChanged` handler as other config file watchers, which clears Prettier's internal cache to ensure fresh ignore data is used

Fixes #3942

## Test plan
- [ ] Add or modify a `.prettierignore` file while the extension is running
- [ ] Verify that the extension respects the new ignore patterns without requiring a reload
- [ ] Test that files previously ignored are now formatted (and vice versa) after modifying `.prettierignore`

🤖 Generated with [Claude Code](https://claude.ai/code)