### PR TITLE
Use formatWithCursor() to preserve cursor position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+- Preserve cursor position after formatting using Prettier's `formatWithCursor()` API (#3939)
+
 ## [12.2.0]
 
 - Fixed `source.fixAll.prettier` code action running even when `editor.defaultFormatter` was set to a different extension (#3908). The code action now respects the user's formatter choice and only runs when Prettier is the default formatter or when `source.fixAll.prettier` is explicitly enabled.

--- a/src/ModuleResolverWeb.ts
+++ b/src/ModuleResolverWeb.ts
@@ -1,4 +1,6 @@
 import {
+  PrettierCursorOptions,
+  PrettierCursorResult,
   PrettierFileInfoOptions,
   PrettierFileInfoResult,
   PrettierSupportLanguage,
@@ -69,6 +71,15 @@ export class ModuleResolver implements ModuleResolverInterface {
       version: prettierVersion,
       format: async (source: string, options: PrettierOptions) => {
         return prettierStandalone.format(source, { ...options, plugins });
+      },
+      formatWithCursor: async (
+        source: string,
+        options: PrettierCursorOptions,
+      ): Promise<PrettierCursorResult> => {
+        return prettierStandalone.formatWithCursor(source, {
+          ...options,
+          plugins,
+        });
       },
       resolveConfigFile: async (): Promise<string | null> => {
         // Config file resolution not supported in browser

--- a/src/PrettierDynamicInstance.ts
+++ b/src/PrettierDynamicInstance.ts
@@ -1,6 +1,12 @@
 import * as path from "path";
 import { pathToFileURL } from "url";
-import type { FileInfoOptions, Options, ResolveConfigOptions } from "prettier";
+import type {
+  CursorOptions,
+  CursorResult,
+  FileInfoOptions,
+  Options,
+  ResolveConfigOptions,
+} from "prettier";
 import type {
   PrettierFileInfoResult,
   PrettierPlugin,
@@ -60,6 +66,16 @@ export const PrettierDynamicInstance: PrettierInstanceConstructor = class Pretti
       await this.import();
     }
     return this.prettierModule!.format(source, options);
+  }
+
+  public async formatWithCursor(
+    source: string,
+    options: CursorOptions,
+  ): Promise<CursorResult> {
+    if (!this.prettierModule) {
+      await this.import();
+    }
+    return this.prettierModule!.formatWithCursor(source, options);
   }
 
   public async getFileInfo(

--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -5,6 +5,7 @@ import {
   DocumentFilter,
   languages,
   Range,
+  Selection,
   TextDocument,
   TextEdit,
   TextEditor,
@@ -22,6 +23,8 @@ import {
   ExtensionFormattingOptions,
   ModuleResolverInterface,
   PrettierBuiltInParserName,
+  PrettierCursorOptions,
+  PrettierCursorResult,
   PrettierFileInfoResult,
   PrettierInstance,
   PrettierModule,
@@ -102,6 +105,11 @@ async function resolvePluginPaths(
 interface ISelectors {
   rangeLanguageSelector: ReadonlyArray<DocumentFilter>;
   languageSelector: ReadonlyArray<DocumentFilter>;
+}
+
+interface FormatResult {
+  formatted: string;
+  cursorOffset: number;
 }
 
 export default class PrettierEditService implements Disposable {
@@ -448,14 +456,30 @@ export default class PrettierEditService implements Disposable {
     options: ExtensionFormattingOptions,
   ): Promise<TextEdit[]> => {
     const startTime = new Date().getTime();
-    const result = await this.format(document.getText(), document, options);
+
+    // Get cursor offset from active editor if available and not doing range formatting
+    const editor = window.activeTextEditor;
+    const isRangeFormatting =
+      options.rangeStart !== undefined && options.rangeEnd !== undefined;
+    let cursorOffset: number | undefined;
+
+    if (editor && editor.document === document && !isRangeFormatting) {
+      cursorOffset = document.offsetAt(editor.selection.active);
+    }
+
+    const result = await this.format(
+      document.getText(),
+      document,
+      options,
+      cursorOffset,
+    );
     if (!result) {
       // No edits happened, return never so VS Code can try other formatters
       return [];
     }
     const duration = new Date().getTime() - startTime;
     this.loggingService.logInfo(`Formatting completed in ${duration}ms.`);
-    const edit = this.minimalEdit(document, result);
+    const edit = this.minimalEdit(document, result.formatted);
     if (!edit) {
       // Document is already formatted, no changes needed
       this.loggingService.logDebug(
@@ -463,6 +487,27 @@ export default class PrettierEditService implements Disposable {
       );
       return [];
     }
+
+    // Schedule cursor repositioning after VS Code applies the edit
+    // We use setImmediate to run after the current event loop completes
+    if (
+      editor &&
+      editor.document === document &&
+      !isRangeFormatting &&
+      result.cursorOffset >= 0
+    ) {
+      setImmediate(() => {
+        // Verify the editor is still active and document hasn't changed
+        if (
+          window.activeTextEditor === editor &&
+          editor.document === document
+        ) {
+          const newPosition = document.positionAt(result.cursorOffset);
+          editor.selection = new Selection(newPosition, newPosition);
+        }
+      });
+    }
+
     return [edit];
   };
 
@@ -505,14 +550,17 @@ export default class PrettierEditService implements Disposable {
   /**
    * Format the given text with user's configuration.
    * @param text Text to format
-   * @param path formatting file's path
-   * @returns {string} formatted text
+   * @param doc TextDocument being formatted
+   * @param options Formatting options
+   * @param cursorOffset Optional cursor offset for cursor preservation
+   * @returns FormatResult with formatted text and new cursor offset, or undefined if formatting failed
    */
   private async format(
     text: string,
     doc: TextDocument,
     options: ExtensionFormattingOptions,
-  ): Promise<string | undefined> {
+    cursorOffset?: number,
+  ): Promise<FormatResult | undefined> {
     const { fileName, uri, languageId } = doc;
 
     this.loggingService.logInfo(`Formatting ${uri}`);
@@ -631,18 +679,53 @@ export default class PrettierEditService implements Disposable {
     this.loggingService.logInfo("Prettier Options:", prettierOptions);
 
     try {
+      // Use formatWithCursor if we have a cursor offset to preserve cursor position
+      if (cursorOffset !== undefined) {
+        const cursorOptions: PrettierCursorOptions = {
+          ...prettierOptions,
+          cursorOffset,
+        };
+
+        // Check if formatWithCursor is available (it should be for all modern Prettier versions)
+        if ("formatWithCursor" in prettierInstance) {
+          try {
+            const result: PrettierCursorResult =
+              await prettierInstance.formatWithCursor(text, cursorOptions);
+            this.statusBar.update(FormatterStatus.Success);
+            return {
+              formatted: result.formatted,
+              cursorOffset: result.cursorOffset,
+            };
+          } catch (cursorError) {
+            // formatWithCursor can fail with some plugins that don't implement locStart/locEnd
+            // Fall back to regular format() in this case
+            this.loggingService.logDebug(
+              "formatWithCursor failed, falling back to format()",
+              cursorError,
+            );
+          }
+        }
+      }
+
+      // Fallback to regular format() if no cursor offset or formatWithCursor not available/failed
       const formattedText = await prettierInstance.format(
         text,
         prettierOptions,
       );
       this.statusBar.update(FormatterStatus.Success);
 
-      return formattedText;
+      return {
+        formatted: formattedText,
+        cursorOffset: -1, // Indicate that cursor position is unknown
+      };
     } catch (error) {
       this.loggingService.logError("Error formatting document.", error);
       this.statusBar.update(FormatterStatus.Error);
 
-      return text;
+      return {
+        formatted: text,
+        cursorOffset: cursorOffset ?? -1,
+      };
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type PrettierBuiltInParserName = prettier.BuiltInParserName;
 export type PrettierResolveConfigOptions = prettier.ResolveConfigOptions;
 export type PrettierOptions = prettier.Options;
 export type PrettierFileInfoOptions = prettier.FileInfoOptions;
+export type PrettierCursorOptions = prettier.CursorOptions;
+export type PrettierCursorResult = prettier.CursorResult;
 
 export type PrettierPlugin = prettier.Plugin<any> | string | URL;
 
@@ -15,6 +17,10 @@ export interface PrettierInstance {
   version: string | null;
   import(): Promise<string>;
   format(source: string, options?: PrettierOptions): Promise<string>;
+  formatWithCursor(
+    source: string,
+    options: PrettierCursorOptions,
+  ): Promise<PrettierCursorResult>;
   getFileInfo(
     filePath: string,
     fileInfoOptions?: PrettierFileInfoOptions,
@@ -41,6 +47,10 @@ export interface PrettierInstanceConstructor {
 export type PrettierModule = {
   version: string;
   format(source: string, options?: PrettierOptions): Promise<string>;
+  formatWithCursor(
+    source: string,
+    options: PrettierCursorOptions,
+  ): Promise<PrettierCursorResult>;
   getSupportInfo(options?: {
     plugins?: Array<string | PrettierPlugin>;
   }): Promise<{ languages: PrettierSupportLanguage[] }>;


### PR DESCRIPTION
## Summary

- Use Prettier's `formatWithCursor()` API instead of `format()` to preserve cursor position after formatting
- The cursor no longer jumps to an arbitrary position when formatting a document
- Properly handles edge cases like range formatting (where cursor position doesn't apply) and older Prettier versions

## Changes

- **types.ts**: Added `PrettierCursorOptions` and `PrettierCursorResult` type exports, and added `formatWithCursor` method to `PrettierInstance` and `PrettierModule` interfaces
- **PrettierDynamicInstance.ts**: Implemented `formatWithCursor` method that delegates to the underlying Prettier module
- **ModuleResolverWeb.ts**: Added `formatWithCursor` support for the browser/web extension
- **PrettierEditService.ts**: 
  - Updated `format()` to optionally use `formatWithCursor()` when a cursor offset is available
  - Updated `provideEdits()` to capture cursor position before formatting and schedule cursor repositioning after VS Code applies the edit
  - Skips cursor handling for range formatting where cursor preservation doesn't make sense

## Test plan

- [ ] Open a file with some unformatted code
- [ ] Place cursor somewhere in the middle of the file
- [ ] Format the document (Cmd/Ctrl+Shift+I or format on save)
- [ ] Verify cursor position is preserved at the equivalent location in the formatted output
- [ ] Test range formatting still works correctly (cursor handling is skipped)
- [ ] Test in browser/web extension environment

Fixes #3939

Generated with [Claude Code](https://claude.ai/code)