### PR TITLE
Security: Skip config resolution in untrusted workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 
 ## [Unreleased]
 
+- **Security**: Fixed config resolution in untrusted workspaces to prevent JavaScript config files (`.prettierrc.js`, `prettier.config.js`, etc.) from being executed. Previously, even when workspace trust was enforced for module resolution, Prettier's config resolution could still `require()`/`import()` JS config files, allowing arbitrary code execution. Reported by Hector Ruiz Ruiz.
+
 ## [12.3.0]
 
 - Watch `.prettierignore` for changes to invalidate cache (#3942)

--- a/src/ModuleResolverNode.ts
+++ b/src/ModuleResolverNode.ts
@@ -15,6 +15,7 @@ import {
   INVALID_PRETTIER_CONFIG,
   INVALID_PRETTIER_PATH_MESSAGE,
   OUTDATED_PRETTIER_VERSION_MESSAGE,
+  UNTRUSTED_WORKSPACE_SKIPPING_CONFIG,
   UNTRUSTED_WORKSPACE_USING_BUNDLED_PRETTIER,
   USING_BUNDLED_PRETTIER,
 } from "./message.js";
@@ -402,6 +403,15 @@ export class ModuleResolver implements ModuleResolverInterface {
     fileName: string,
     vscodeConfig: PrettierVSCodeConfig,
   ): Promise<"error" | "disabled" | PrettierOptions | null> {
+    // In untrusted workspaces, skip config resolution entirely.
+    // Prettier's resolveConfigFile/resolveConfig can execute JS config files
+    // (.prettierrc.js, prettier.config.js, etc.) which would allow arbitrary
+    // code execution.
+    if (!workspace.isTrusted) {
+      this.loggingService.logDebug(UNTRUSTED_WORKSPACE_SKIPPING_CONFIG);
+      return null;
+    }
+
     let configPath: string | undefined;
     try {
       configPath =

--- a/src/ModuleResolverNode.ts
+++ b/src/ModuleResolverNode.ts
@@ -409,6 +409,9 @@ export class ModuleResolver implements ModuleResolverInterface {
     // code execution.
     if (!workspace.isTrusted) {
       this.loggingService.logDebug(UNTRUSTED_WORKSPACE_SKIPPING_CONFIG);
+      if (vscodeConfig.requireConfig) {
+        return "disabled";
+      }
       return null;
     }
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -13,3 +13,5 @@ export const EXTENSION_DISABLED =
   "Extension is disabled. No formatters will be registered. To enable, change the `prettier.enable` to `true` and restart VS Code.";
 export const UNTRUSTED_WORKSPACE_USING_BUNDLED_PRETTIER =
   "This workspace is not trusted. Using the bundled version of prettier.";
+export const UNTRUSTED_WORKSPACE_SKIPPING_CONFIG =
+  "Skipping Prettier config resolution in untrusted workspace. Config files are not loaded for security.";


### PR DESCRIPTION
## Summary

- **Fixes a security vulnerability (CVSS 7.8)** where Prettier's config resolution could execute JavaScript config files (`.prettierrc.js`, `prettier.config.js`, `.prettierrc.cjs`) in untrusted workspaces, bypassing workspace trust protections
- Adds a `workspace.isTrusted` guard at the top of `resolveConfig()` in `ModuleResolverNode.ts` that returns `null` (use Prettier defaults) when the workspace is untrusted
- This single guard covers both vulnerable call paths: the formatting path (`format()` → `getResolvedConfig()` → `resolveConfig()`) and the plugin discovery path (`getSelectors()` → `resolveConfig()`)

## Security Details

When a workspace is untrusted, `getPrettierInstance()` correctly forces the bundled Prettier. However, `resolveConfig()` still called Prettier's `resolveConfigFile()`/`resolveConfig()`, which internally `require()`/`import()` JavaScript config files — allowing arbitrary code execution in the extension host with the user's privileges.

Reported by Hector Ruiz Ruiz (discovered 10/12/2025).

## Test plan

- [ ] Verify `npm run compile` succeeds
- [ ] Verify `npm test` passes with no regressions
- [ ] Manual test: create a workspace with a `.prettierrc.cjs` containing a side-effect (e.g., `require('fs').writeFileSync('/tmp/test-vuln', 'executed')`), open it as untrusted, format a file, confirm the side-effect does NOT occur
- [ ] Verify formatting still works in trusted workspaces with JS config files

🤖 Generated with [Claude Code](https://claude.com/claude-code)